### PR TITLE
{collect, transform}: Walk the AST once

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -29,24 +29,6 @@ func (g *generator) Generate(sections []*markdownSection) error {
 	return nil
 }
 
-func (g *generator) renderItem(item markdownItem) error {
-	if g.idx > 0 {
-		io.WriteString(g.W, "\n")
-	}
-	g.idx++
-
-	switch item := item.(type) {
-	case *markdownTitle:
-		return g.renderTitle(item)
-
-	case *markdownFile:
-		return g.renderFile(item)
-
-	default:
-		panic(fmt.Sprintf("unknown markdown item type %T", item))
-	}
-}
-
 func (g *generator) renderSection(sec *markdownSection) error {
 	if t := sec.Title; t != nil {
 		if err := g.Renderer.Render(g.W, sec.Source, t.AST.Node); err != nil {
@@ -61,7 +43,25 @@ func (g *generator) renderSection(sec *markdownSection) error {
 	return nil
 }
 
-func (g *generator) renderTitle(title *markdownTitle) error {
+func (g *generator) renderItem(item markdownItem) error {
+	if g.idx > 0 {
+		io.WriteString(g.W, "\n")
+	}
+	g.idx++
+
+	switch item := item.(type) {
+	case *markdownGroupItem:
+		return g.renderGroupItem(item)
+
+	case *markdownFileItem:
+		return g.renderFileItem(item)
+
+	default:
+		panic(fmt.Sprintf("unknown markdown item type %T", item))
+	}
+}
+
+func (g *generator) renderGroupItem(title *markdownGroupItem) error {
 	heading := ast.NewHeading(title.Depth + 1) // depth => level
 	heading.AppendChild(heading, ast.NewString([]byte(title.Text)))
 
@@ -73,6 +73,6 @@ func (g *generator) renderTitle(title *markdownTitle) error {
 	return nil
 }
 
-func (g *generator) renderFile(file *markdownFile) error {
+func (g *generator) renderFileItem(file *markdownFileItem) error {
 	return g.Renderer.Render(g.W, file.File.Source, file.File.AST.Node)
 }

--- a/main.go
+++ b/main.go
@@ -117,7 +117,7 @@ func (cmd *mainCmd) run(opts *params) error {
 		return err
 	}
 
-	filesByPath := make(map[string]*markdownFile)
+	filesByPath := make(map[string]*markdownFileItem)
 	sections, err := (&collector{
 		FS:     os.DirFS(opts.Dir),
 		Parser: mdParser,


### PR DESCRIPTION
Instead of walking the AST once during collect,
and again during transform, do it only once.
collect gathers references to all nodes of interest during its walk,
and transform operates on already gathered references.
