### PR TITLE
pos: Delete Positioner interface

### DIFF
--- a/internal/pos/err.go
+++ b/internal/pos/err.go
@@ -26,13 +26,22 @@ func (e *Error) Unwrap() error {
 //
 // ErrorList is not thread-safe.
 type ErrorList struct {
-	conv Positioner
+	conv interface {
+		Position(Pos) Position
+	}
 	errs []*Error
 }
 
 // NewErrorList builds an ErrorList
 // that uses the provided Converter to report positions.
-func NewErrorList(conv Positioner) *ErrorList {
+func NewErrorList(conv *Converter) *ErrorList {
+	return newErrorList(conv)
+}
+
+func newErrorList(conv interface {
+	Position(Pos) Position
+},
+) *ErrorList {
 	return &ErrorList{conv: conv}
 }
 

--- a/internal/pos/err_test.go
+++ b/internal/pos/err_test.go
@@ -28,7 +28,7 @@ func TestErrorList(t *testing.T) {
 		}
 	})
 
-	el := NewErrorList(conv)
+	el := newErrorList(conv)
 
 	t.Run("push", func(t *testing.T) {
 		defer el.Reset()

--- a/internal/pos/pos.go
+++ b/internal/pos/pos.go
@@ -30,13 +30,6 @@ func (p Position) String() string {
 	return string(bs)
 }
 
-// Positioner turns a [Pos] into a [Position].
-type Positioner interface {
-	Position(Pos) Position
-}
-
-var _ Positioner = (*Converter)(nil)
-
 // Converter converts [Pos] to a [Position].
 type Converter struct {
 	file string // optional


### PR DESCRIPTION
The name and usage is annoying -- pos.Positioner, positioner.Position.
Use the Converter implementation directly where relevant.

The interface existed only to make ErrorList testing easier.
We can do that with an anonymous interface.