### PR TITLE
pos: Rename Converter to Info

### DIFF
--- a/collect.go
+++ b/collect.go
@@ -29,7 +29,7 @@ func (c *collector) Collect(f *goldast.File) ([]*markdownSection, error) {
 		return nil, err
 	}
 
-	errs := pos.NewErrorList(f.Positioner)
+	errs := pos.NewErrorList(f.Info)
 	sections := make([]*markdownSection, len(toc.Sections))
 	for i, sec := range toc.Sections {
 		items := tree.TransformList(sec.Items, func(item summary.Item) markdownItem {

--- a/internal/goldast/node.go
+++ b/internal/goldast/node.go
@@ -96,7 +96,7 @@ func (n *Node[T]) AsAny() *Any {
 
 // Pos reports the position of the current block node.
 //
-// Use [pos.Converter] to convert this into a human-readable format.
+// Use [pos.Info] to convert this into a human-readable format.
 func (n *Node[T]) Pos() pos.Pos {
 	if n == nil {
 		return 0

--- a/internal/goldast/parser.go
+++ b/internal/goldast/parser.go
@@ -8,17 +8,14 @@ import (
 
 // File is a parsed Markdown file.
 type File struct {
-	// Name of the file, as passed to Parse.
-	Name string
-
 	// AST is the parsed Markdown file.
 	AST *Any
 
 	// Source is the original Markdown source.
 	Source []byte
 
-	// Positioner maps Pos values in the AST to file positions.
-	Positioner *pos.Converter
+	// Info holds position information about the file.
+	Info *pos.Info
 
 	// Pos is the starting position for this document.
 	Pos pos.Pos
@@ -27,7 +24,7 @@ type File struct {
 // Position turns the given Pos into a Position
 // using this file's position information.
 func (f *File) Position(p pos.Pos) pos.Position {
-	return f.Positioner.Position(p)
+	return f.Info.Position(p)
 }
 
 // Parse parses a Markdown document using the provided Goldmark parser.
@@ -40,10 +37,9 @@ func Parse(p parser.Parser, filename string, src []byte, opts ...parser.ParseOpt
 	}
 
 	return &File{
-		Name:       filename,
-		AST:        n,
-		Source:     src,
-		Pos:        n.Pos(),
-		Positioner: pos.FromContent(filename, src),
+		AST:    n,
+		Source: src,
+		Pos:    n.Pos(),
+		Info:   pos.FromContent(filename, src),
 	}, nil
 }

--- a/internal/goldast/parser_test.go
+++ b/internal/goldast/parser_test.go
@@ -14,7 +14,6 @@ func TestParse(t *testing.T) {
 	f, err := Parse(parser, "foo.md", []byte("hello world"))
 	require.NoError(t, err)
 
-	require.Equal(t, "foo.md", f.Name)
 	require.Equal(t, "hello world", string(f.Source))
-	require.Equal(t, "foo.md:1:1", f.Positioner.Position(f.Pos).String())
+	require.Equal(t, "foo.md:1:1", f.Info.Position(f.Pos).String())
 }

--- a/internal/goldast/walk_test.go
+++ b/internal/goldast/walk_test.go
@@ -26,7 +26,7 @@ func TestWalk(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	posc := f.Positioner
+	posc := f.Info
 	require.Len(t, nodes, 5)
 	if n := nodes[0]; assert.IsType(t, new(ast.Document), n.Node) {
 		assert.Equal(t, "foo.md:1:1", posc.Position(n.Pos()).String(), "document")

--- a/internal/pos/err.go
+++ b/internal/pos/err.go
@@ -26,23 +26,23 @@ func (e *Error) Unwrap() error {
 //
 // ErrorList is not thread-safe.
 type ErrorList struct {
-	conv interface {
+	info interface {
 		Position(Pos) Position
 	}
 	errs []*Error
 }
 
 // NewErrorList builds an ErrorList
-// that uses the provided Converter to report positions.
-func NewErrorList(conv *Converter) *ErrorList {
-	return newErrorList(conv)
+// that uses the provided [Info] to report positions.
+func NewErrorList(info *Info) *ErrorList {
+	return newErrorList(info)
 }
 
-func newErrorList(conv interface {
+func newErrorList(info interface {
 	Position(Pos) Position
 },
 ) *ErrorList {
-	return &ErrorList{conv: conv}
+	return &ErrorList{info: info}
 }
 
 // Pushf builds an error with the given message and arguments,
@@ -78,7 +78,7 @@ func (el *ErrorList) Err() error {
 	var errs []error
 	for _, e := range el.errs {
 		errs = append(errs,
-			fmt.Errorf("%v:%w", el.conv.Position(e.Pos), e.Err))
+			fmt.Errorf("%v:%w", el.info.Position(e.Pos), e.Err))
 	}
 	return errors.Join(errs...)
 }

--- a/internal/pos/err_test.go
+++ b/internal/pos/err_test.go
@@ -16,7 +16,7 @@ func TestError(t *testing.T) {
 }
 
 func TestErrorList(t *testing.T) {
-	conv := fakePositioner(func(pos Pos) Position {
+	info := fakeInfo(func(pos Pos) Position {
 		switch pos {
 		case 42:
 			return Position{File: "foo", Line: 42, Column: 13}
@@ -28,7 +28,7 @@ func TestErrorList(t *testing.T) {
 		}
 	})
 
-	el := newErrorList(conv)
+	el := newErrorList(info)
 
 	t.Run("push", func(t *testing.T) {
 		defer el.Reset()
@@ -54,8 +54,8 @@ func TestErrorList(t *testing.T) {
 	})
 }
 
-type fakePositioner func(Pos) Position
+type fakeInfo func(Pos) Position
 
-func (f fakePositioner) Position(pos Pos) Position {
+func (f fakeInfo) Position(pos Pos) Position {
 	return f(pos)
 }

--- a/internal/pos/pos.go
+++ b/internal/pos/pos.go
@@ -30,8 +30,9 @@ func (p Position) String() string {
 	return string(bs)
 }
 
-// Converter converts [Pos] to a [Position].
-type Converter struct {
+// Info holds richer position information.
+// It can be used to convert a Pos to a human-readable Position.
+type Info struct {
 	file string // optional
 	size int    // size of file
 	// lines is a list of offsets at which each line starts in source.
@@ -40,11 +41,11 @@ type Converter struct {
 	lines []int
 }
 
-// FromContent builds a position converter from the given source data.
+// FromContent builds a position [Info] from the given source data.
 //
 // Filename is optional.
-func FromContent(filename string, src []byte) *Converter {
-	con := Converter{file: filename, size: len(src)}
+func FromContent(filename string, src []byte) *Info {
+	con := Info{file: filename, size: len(src)}
 
 	var line int // first line starts at 0
 	for idx, c := range src {
@@ -60,11 +61,16 @@ func FromContent(filename string, src []byte) *Converter {
 	return &con
 }
 
+// Filename reports the name of the file as passed to FromContent.
+func (c *Info) Filename() string {
+	return c.file
+}
+
 // Position reports the human-readable position
 // for the given offset in the file.
 //
 // Position panics if the offset is out of bounds of the file.
-func (c *Converter) Position(pos Pos) Position {
+func (c *Info) Position(pos Pos) Position {
 	offset := int(pos) // pos is just an offset for now
 	if offset == 0 {
 		return Position{File: c.file, Line: 1, Column: 1}

--- a/internal/pos/pos_test.go
+++ b/internal/pos/pos_test.go
@@ -36,25 +36,26 @@ func TestPosition_String(t *testing.T) {
 	}
 }
 
-func TestConverter_Position_empty(t *testing.T) {
+func TestInfo_Position_empty(t *testing.T) {
 	t.Parallel()
 
-	conv := FromContent("foo", nil)
+	info := FromContent("foo", nil)
 	assert.Equal(t, Position{
 		File:   "foo",
 		Line:   1,
 		Column: 1,
-	}, conv.Position(0))
+	}, info.Position(0))
 
 	assert.Panics(t, func() {
-		conv.Position(1)
+		info.Position(1)
 	}, "out of range lookup should panic")
 }
 
-func TestConverter_Position(t *testing.T) {
+func TestInfo_Position(t *testing.T) {
 	t.Parallel()
 
-	conv := FromContent("a.txt", []byte("foo\nbar\nbaz\n"))
+	info := FromContent("a.txt", []byte("foo\nbar\nbaz\n"))
+	assert.Equal(t, "a.txt", info.Filename())
 
 	tests := []struct {
 		give Pos
@@ -78,7 +79,7 @@ func TestConverter_Position(t *testing.T) {
 		t.Run(fmt.Sprint(tt.give), func(t *testing.T) {
 			// t.Parallel()
 			//
-			assert.Equal(t, tt.want, conv.Position(tt.give))
+			assert.Equal(t, tt.want, info.Position(tt.give))
 		})
 	}
 }

--- a/internal/summary/parse.go
+++ b/internal/summary/parse.go
@@ -32,7 +32,7 @@ import (
 //
 // Anything else will result in an error.
 func Parse(f *goldast.File) (*TOC, error) {
-	errs := pos.NewErrorList(f.Positioner)
+	errs := pos.NewErrorList(f.Info)
 	parser := newTOCParser(f.Source, errs)
 	parser.parseSections(f.AST)
 	if len(parser.sections) == 0 && errs.Len() == 0 {


### PR DESCRIPTION
Converter is an ungainly name to deal with.
Rename it to Info, and rename the variable everywhere similarly.
Info now also exposes the filename so that it may be used elsewhere.