### PR TITLE
Don't leak Summary types during collection

### DIFF
--- a/internal/goldast/node.go
+++ b/internal/goldast/node.go
@@ -51,6 +51,11 @@ func Wrap[T ast.Node](n T) (*Node[T], error) {
 	return &Node[T]{Node: n, pos: p}, nil
 }
 
+// WithPos builds a node with a given position.
+func WithPos[T ast.Node](n T, p pos.Pos) *Node[T] {
+	return &Node[T]{Node: n, pos: p}
+}
+
 // Cast casts the value inside a node
 // reporting whether the cast was successful.
 //

--- a/main.go
+++ b/main.go
@@ -118,7 +118,7 @@ func (cmd *mainCmd) run(opts *params) error {
 	}
 
 	filesByPath := make(map[string]*markdownFileItem)
-	sections, err := (&collector{
+	coll, err := (&collector{
 		FS:     os.DirFS(opts.Dir),
 		Parser: mdParser,
 		IDGen:  header.NewIDGen(),
@@ -132,7 +132,7 @@ func (cmd *mainCmd) run(opts *params) error {
 	(&transformer{
 		Files: filesByPath,
 		Log:   cmd.log,
-	}).transformList(sections)
+	}).Transform(coll)
 
 	render := mdfmt.NewRenderer()
 	render.AddMarkdownOptions(
@@ -144,5 +144,5 @@ func (cmd *mainCmd) run(opts *params) error {
 		Renderer: render,
 		Log:      cmd.log,
 	}
-	return g.Generate(sections)
+	return g.Generate(coll)
 }

--- a/transform.go
+++ b/transform.go
@@ -16,10 +16,13 @@ type transformer struct {
 
 	// Level of the current section's header, if any.
 	sectionLevel int
+
+	tocFile *goldast.File
 }
 
-func (t *transformer) transformList(sections []*markdownSection) {
-	for _, sec := range sections {
+func (t *transformer) Transform(coll *markdownCollection) {
+	t.tocFile = coll.TOCFile
+	for _, sec := range coll.Sections {
 		t.sectionLevel = sec.TitleLevel()
 		sec.Items.Walk(func(item markdownItem) error {
 			t.transformItem(item)
@@ -39,33 +42,34 @@ func (t *transformer) transformItem(item markdownItem) {
 	}
 }
 
-func (t *transformer) transformTitle(title *markdownGroupItem) {
-	title.Depth += t.sectionLevel
+func (t *transformer) transformTitle(group *markdownGroupItem) {
+	group.Heading.AST.Node.Level += group.TOCDepth + t.sectionLevel
 
 	// Replace "Foo" in the list with "[Foo](#foo)".
-	item := title.AST
+	item := group.TOCText
 	parent := item.Node.Parent()
 
 	link := ast.NewLink()
-	link.Destination = []byte("#" + title.ID)
+	link.Destination = []byte("#" + group.Heading.ID)
 	parent.ReplaceChild(parent, item.Node, link)
 
 	link.AppendChild(link, item.Node)
 }
 
 func (t *transformer) transformFile(f *markdownFileItem) {
-	_ = t.transformLink(".", f.Item.AST) // TODO: handle error
-	dir := filepath.Dir(f.Path)
-	file := f.File
+	if err := t.transformLink(".", f.TOCLink); err != nil {
+		t.Log.Printf("%v:%v", t.tocFile.Position(f.TOCLink.Pos()), err)
+	}
 
+	dir := filepath.Dir(f.Path)
 	for _, l := range f.Links {
 		if err := t.transformLink(dir, l); err != nil {
-			t.Log.Printf("%v:%v", file.Position(l.Pos()), err)
+			t.Log.Printf("%v:%v", f.File.Position(l.Pos()), err)
 		}
 	}
 
 	for _, h := range f.Headings {
-		h.AST.Node.Level += f.Item.ItemDepth() + t.sectionLevel
+		h.AST.Node.Level += f.TOCDepth + t.sectionLevel
 	}
 }
 


### PR DESCRIPTION
collector now extracts only the information needed
for transform and generate.
Everything else is discarded.

Disconnecting these types clarifies the boundaries further.
Transform can now, for example,
disard all the extraneous information and generate
just what is necessary for render.