### PR TITLE
Rename to stitchmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# mdreduce
+# stitchmd
 
-mdreduce is a tool that generates
+stitchmd is a tool that generates
 large Markdown files from several smaller files.
 It lets you define your desired layout as a table of contents,
 and then it reads and combines all the files together.
@@ -10,34 +10,34 @@ See [Usage](#usage) for a demonstration.
 ## Features
 
 - **Cross-linking**:
-  mdreduce recognizes cross-links between input Markdown files
+  stitchmd recognizes cross-links between input Markdown files
   and automatically rewrites them to be local header links
   in the generated output file.
   This keeps your input files, as well as the output file
   independently browsable.
 - **Header offsetting**:
-  mdreduce will adjust heading levels of included Markdown files
+  stitchmd will adjust heading levels of included Markdown files
   based on the hierarchy you specify in the summary file.
 
 ## Installation
 
-Install mdreduce from source with the following command:
+Install stitchmd from source with the following command:
 
 ```bash
-$ go install go.abhg.dev/mdreduce@latest
+$ go install go.abhg.dev/stitchmd@latest
 ```
 
 <!-- TODO: binary installation once goreleaser is set up. -->
 
 ## Usage
 
-To use mdreduce, run it with a Markdown file
+To use stitchmd, run it with a Markdown file
 defining the layout of your combined file.
 This input file is referred to as the **summary file**,
 and is typically named "summary.md".
 
 ```bash
-mdreduce summary.md
+stitchmd summary.md
 ```
 
 The table of contents in the summary file is a list of one or more **sections**,
@@ -69,7 +69,7 @@ Some things to note about the input format:
 
 <!-- TODO: document syntax explicitly in a separate section. -->
 
-The output of mdreduce will be a single Markdown file with the
+The output of stitchmd will be a single Markdown file with the
 contents of all the listed files inline,
 with their links rewritten to match their new location.
 

--- a/collect.go
+++ b/collect.go
@@ -6,11 +6,11 @@ import (
 
 	"github.com/yuin/goldmark/ast"
 	"github.com/yuin/goldmark/parser"
-	"go.abhg.dev/mdreduce/internal/goldast"
-	"go.abhg.dev/mdreduce/internal/header"
-	"go.abhg.dev/mdreduce/internal/pos"
-	"go.abhg.dev/mdreduce/internal/summary"
-	"go.abhg.dev/mdreduce/internal/tree"
+	"go.abhg.dev/stitchmd/internal/goldast"
+	"go.abhg.dev/stitchmd/internal/header"
+	"go.abhg.dev/stitchmd/internal/pos"
+	"go.abhg.dev/stitchmd/internal/summary"
+	"go.abhg.dev/stitchmd/internal/tree"
 )
 
 // collector loads all Markdown files in a TOC

--- a/flags.go
+++ b/flags.go
@@ -32,7 +32,7 @@ type cliParser struct {
 }
 
 func (p *cliParser) newFlagSet() (*params, *flag.FlagSet) {
-	flag := flag.NewFlagSet("mdreduce", flag.ContinueOnError)
+	flag := flag.NewFlagSet("stitchmd", flag.ContinueOnError)
 	flag.SetOutput(p.Stderr)
 	flag.Usage = func() {
 		fmt.Fprint(p.Stderr, _shortHelp)

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module go.abhg.dev/mdreduce
+module go.abhg.dev/stitchmd
 
 go 1.20
 

--- a/internal/goldast/node.go
+++ b/internal/goldast/node.go
@@ -9,7 +9,7 @@ import (
 	"reflect"
 
 	"github.com/yuin/goldmark/ast"
-	"go.abhg.dev/mdreduce/internal/pos"
+	"go.abhg.dev/stitchmd/internal/pos"
 )
 
 // Node decorates a Goldmark Node with position information.

--- a/internal/goldast/node_test.go
+++ b/internal/goldast/node_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/yuin/goldmark"
 	"github.com/yuin/goldmark/ast"
 	"github.com/yuin/goldmark/text"
-	"go.abhg.dev/mdreduce/internal/pos"
+	"go.abhg.dev/stitchmd/internal/pos"
 )
 
 func TestWrap(t *testing.T) {

--- a/internal/goldast/parser.go
+++ b/internal/goldast/parser.go
@@ -3,7 +3,7 @@ package goldast
 import (
 	"github.com/yuin/goldmark/parser"
 	"github.com/yuin/goldmark/text"
-	"go.abhg.dev/mdreduce/internal/pos"
+	"go.abhg.dev/stitchmd/internal/pos"
 )
 
 // File is a parsed Markdown file.

--- a/internal/goldast/walk.go
+++ b/internal/goldast/walk.go
@@ -2,7 +2,7 @@ package goldast
 
 import (
 	"github.com/yuin/goldmark/ast"
-	"go.abhg.dev/mdreduce/internal/pos"
+	"go.abhg.dev/stitchmd/internal/pos"
 )
 
 // Visitor visits individual nodes in a Goldmark AST.

--- a/internal/summary/parse.go
+++ b/internal/summary/parse.go
@@ -2,9 +2,9 @@ package summary
 
 import (
 	"github.com/yuin/goldmark/ast"
-	"go.abhg.dev/mdreduce/internal/goldast"
-	"go.abhg.dev/mdreduce/internal/pos"
-	"go.abhg.dev/mdreduce/internal/tree"
+	"go.abhg.dev/stitchmd/internal/goldast"
+	"go.abhg.dev/stitchmd/internal/pos"
+	"go.abhg.dev/stitchmd/internal/tree"
 )
 
 // Parse parses a summary from a Markdown document.

--- a/internal/summary/parse_test.go
+++ b/internal/summary/parse_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/yuin/goldmark"
-	"go.abhg.dev/mdreduce/internal/goldast"
-	"go.abhg.dev/mdreduce/internal/tree"
+	"go.abhg.dev/stitchmd/internal/goldast"
+	"go.abhg.dev/stitchmd/internal/tree"
 	"gopkg.in/yaml.v3"
 )
 

--- a/internal/summary/summary.go
+++ b/internal/summary/summary.go
@@ -5,8 +5,8 @@
 package summary
 
 import (
-	"go.abhg.dev/mdreduce/internal/goldast"
-	"go.abhg.dev/mdreduce/internal/tree"
+	"go.abhg.dev/stitchmd/internal/goldast"
+	"go.abhg.dev/stitchmd/internal/tree"
 )
 
 // TOC is the complete summary document.

--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-// mdreduce reads a Markdown file defining a table of contents
+// stitchmd reads a Markdown file defining a table of contents
 // with links to other Markdown files,
 // and reduces it all to a single Markdown file.
 //
@@ -16,8 +16,8 @@ import (
 	mdfmt "github.com/Kunde21/markdownfmt/v3/markdown"
 	"github.com/yuin/goldmark"
 	"github.com/yuin/goldmark/extension"
-	"go.abhg.dev/mdreduce/internal/goldast"
-	"go.abhg.dev/mdreduce/internal/header"
+	"go.abhg.dev/stitchmd/internal/goldast"
+	"go.abhg.dev/stitchmd/internal/header"
 )
 
 var _version = "dev"
@@ -59,7 +59,7 @@ func (cmd *mainCmd) Run(args []string) (exitCode int) {
 	}
 
 	if err := cmd.run(opts); err != nil {
-		fmt.Fprintln(cmd.Stderr, "mdreduce:", err)
+		fmt.Fprintln(cmd.Stderr, "stitchmd:", err)
 		return 1
 	}
 

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,4 +1,4 @@
-module go.abhg.dev/mdreduce/tools
+module go.abhg.dev/stitchmd/tools
 
 go 1.20
 

--- a/transform.go
+++ b/transform.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/yuin/goldmark/ast"
-	"go.abhg.dev/mdreduce/internal/goldast"
+	"go.abhg.dev/stitchmd/internal/goldast"
 )
 
 type transformer struct {

--- a/usage.txt
+++ b/usage.txt
@@ -1,4 +1,4 @@
-USAGE: mdreduce [OPTIONS] FILE
+USAGE: stitchmd [OPTIONS] FILE
 
 Reads a hierarchy of sections from FILE and generates a Markdown file
 with the contents of all linked files combined.


### PR DESCRIPTION
"mdreduce" isn't specific enough.
"stitchmd" at least conveys that we'll be stitching Markdown files
together.