### PR TITLE
summary: Groups must have children

### DIFF
--- a/internal/summary/parse_test.go
+++ b/internal/summary/parse_test.go
@@ -119,19 +119,31 @@ func TestParseSummary(t *testing.T) {
 			),
 		},
 		{
-			desc: "items withouth links",
+			desc: "item groups",
 			give: unlines(
 				"- foo",
-				"- bar",
+				"    - [bar](bar.md)",
 				"    - [baz](baz.md)",
-				"- baz",
 			),
 			want: toc(
 				section(0, "",
-					textItem(0, "foo"),
-					textItem(0, "bar",
-						linkItem(1, "baz", "baz.md")),
-					textItem(0, "baz")),
+					textItem(0, "foo",
+						linkItem(1, "bar", "bar.md"),
+						linkItem(1, "baz", "baz.md"))),
+			),
+		},
+		{
+			desc: "longer group names",
+			give: unlines(
+				"- foo bar baz qux quux.",
+				"    - [bar](bar.md)",
+				"    - [baz](baz.md)",
+			),
+			want: toc(
+				section(0, "",
+					textItem(0, "foo bar baz qux quux.",
+						linkItem(1, "bar", "bar.md"),
+						linkItem(1, "baz", "baz.md"))),
 			),
 		},
 	}

--- a/internal/summary/testdata/parse_errors.yaml
+++ b/internal/summary/testdata/parse_errors.yaml
@@ -22,7 +22,7 @@
             - foo *bar* baz
         - [baz](baz.md)
   want:
-    - 2:7:item has too many children (3)
+    - "2:7:text has too many children (3): [Text Emphasis Text]"
 
 - name: too many children
   give: |
@@ -35,7 +35,7 @@
 
           baz
   want:
-    - 4:7:item has too many children (3)
+    - "4:7:list item has too many children (3): [Paragraph Paragraph Paragraph]"
 
 - name: not a sublist
   give: |
@@ -74,3 +74,13 @@
     Random paragraph
   want:
     - 6:1:expected a list or heading, got Paragraph
+
+- name: items without links
+  give: |
+    - foo
+    - bar
+      - [baz](baz.md)
+    - qux
+  want:
+    - 1:3:text item must have children
+    - 4:3:text item must have children


### PR DESCRIPTION
Items that are just text in the summary must have children
in that they should be for grouping something.
They cannot be lone headers.

This leaves room for turning these into pargraphs later if desired.