### PR TITLE
Handle text split across multiple nodes

### DIFF
--- a/internal/goldast/parser.go
+++ b/internal/goldast/parser.go
@@ -1,6 +1,8 @@
 package goldast
 
 import (
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/extension"
 	"github.com/yuin/goldmark/parser"
 	"github.com/yuin/goldmark/text"
 	"go.abhg.dev/stitchmd/internal/pos"
@@ -42,4 +44,12 @@ func Parse(p parser.Parser, filename string, src []byte, opts ...parser.ParseOpt
 		Pos:    n.Pos(),
 		Info:   pos.FromContent(filename, src),
 	}, nil
+}
+
+// DefaultParser returns the default Goldmark parser we should use in the
+// application.
+func DefaultParser() parser.Parser {
+	return goldmark.New(
+		goldmark.WithExtensions(extension.GFM),
+	).Parser()
 }

--- a/internal/summary/parse_test.go
+++ b/internal/summary/parse_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/yuin/goldmark"
 	"go.abhg.dev/stitchmd/internal/goldast"
 	"go.abhg.dev/stitchmd/internal/tree"
 	"gopkg.in/yaml.v3"
@@ -153,7 +152,7 @@ func TestParseSummary(t *testing.T) {
 		t.Run(tt.desc, func(t *testing.T) {
 			t.Parallel()
 
-			f, err := goldast.Parse(goldmark.DefaultParser(), "", []byte(tt.give))
+			f, err := goldast.Parse(goldast.DefaultParser(), "", []byte(tt.give))
 			require.NoError(t, err)
 
 			got, err := Parse(f)
@@ -203,7 +202,7 @@ func TestParseSummaryErrors(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 
-			f, err := goldast.Parse(goldmark.DefaultParser(), tt.Filename, []byte(tt.Give))
+			f, err := goldast.Parse(goldast.DefaultParser(), tt.Filename, []byte(tt.Give))
 			require.NoError(t, err)
 			defer func() {
 				if t.Failed() {

--- a/main.go
+++ b/main.go
@@ -14,8 +14,6 @@ import (
 	"path/filepath"
 
 	mdfmt "github.com/Kunde21/markdownfmt/v3/markdown"
-	"github.com/yuin/goldmark"
-	"github.com/yuin/goldmark/extension"
 	"go.abhg.dev/stitchmd/internal/goldast"
 	"go.abhg.dev/stitchmd/internal/header"
 )
@@ -108,9 +106,7 @@ func (cmd *mainCmd) run(opts *params) error {
 		return fmt.Errorf("read input: %w", err)
 	}
 
-	mdParser := goldmark.New(
-		goldmark.WithExtensions(extension.GFM),
-	).Parser()
+	mdParser := goldast.DefaultParser()
 
 	f, err := goldast.Parse(mdParser, filename, src)
 	if err != nil {


### PR DESCRIPTION
The parser will sometimes split multi-word text nodes,
especially with the GFM extension,
into multiple text nodes instead of a single node.

Combine those nodes back into a single text node
before attempting to parse their contents.