### PR TITLE
Automatic titles for pages without one

### DIFF
--- a/collect.go
+++ b/collect.go
@@ -123,6 +123,10 @@ type markdownFileItem struct {
 	// Title is the title of the Markdown file, if any.
 	Title *markdownHeading
 
+	// TOCTitle is the title for this file generated from the TOC text.
+	// Only one of Title and TOCTitle is set.
+	TOCTitle *markdownHeading
+
 	// Path is the path to the Markdown file.
 	Path string
 
@@ -191,6 +195,13 @@ func (c *collector) collectFileItem(item *summary.LinkItem) (*markdownFileItem, 
 	}
 	if len(h1s) == 1 {
 		mf.Title = h1s[0]
+	} else {
+		heading := ast.NewHeading(1)
+		heading.AppendChild(
+			heading,
+			ast.NewString([]byte(item.Text)),
+		)
+		mf.TOCTitle = c.newHeading(f, fidgen, goldast.WithPos(heading, f.Pos))
 	}
 
 	c.files[item.Target] = mf

--- a/generate.go
+++ b/generate.go
@@ -70,5 +70,11 @@ func (g *generator) renderGroupItem(group *markdownGroupItem) error {
 }
 
 func (g *generator) renderFileItem(file *markdownFileItem) error {
+	if t := file.TOCTitle; t != nil {
+		if err := g.Renderer.Render(g.W, file.File.Source, t.AST.Node); err != nil {
+			return err
+		}
+		io.WriteString(g.W, "\n\n")
+	}
 	return g.Renderer.Render(g.W, file.File.Source, file.File.AST.Node)
 }

--- a/testdata/integration/basic.yaml
+++ b/testdata/integration/basic.yaml
@@ -230,3 +230,149 @@
     ### How to do a thing?
 
     To do a thing, start by doing it.
+
+- name: no titles
+  give: |
+    - [Foo](foo.md)
+    - [Bar](bar.md)
+  files:
+    foo.md: "foo does stuff"
+    bar.md: "bar does other stuff"
+  want: |
+    - [Foo](#foo)
+    - [Bar](#bar)
+
+    # Foo
+
+    foo does stuff
+
+    # Bar
+
+    bar does other stuff
+
+- name: multiple h1s
+  give: |
+    - [Introduction](intro.md)
+    - Guide
+      - [Concepts](concepts.md)
+  files:
+    intro.md: |
+      # Getting Started
+
+      Foo
+
+      # Installation
+
+      Bar
+    concepts.md: |
+      # Concept Foo
+
+      Foo
+
+      # Concept Bar
+
+      Bar
+  want: |
+    - [Introduction](#introduction)
+    - [Guide](#guide)
+      - [Concepts](#concepts)
+
+    # Introduction
+
+    ## Getting Started
+
+    Foo
+
+    ## Installation
+
+    Bar
+
+    # Guide
+
+    ## Concepts
+
+    ### Concept Foo
+
+    Foo
+
+    ### Concept Bar
+
+    Bar
+
+- name: no h1s
+  give: |
+    - [Foo](foo.md)
+    - [Bar](bar.md)
+  files:
+    foo.md: |
+      ## A
+
+      ## B
+
+      ## C
+    bar.md: |
+      ## D
+
+      ## E
+
+      ## F
+  want: |
+    - [Foo](#foo)
+    - [Bar](#bar)
+
+    # Foo
+
+    ## A
+
+    ## B
+
+    ## C
+
+    # Bar
+
+    ## D
+
+    ## E
+
+    ## F
+
+- name: no h1s with section title
+  give: |
+    ## Items
+
+    - [Foo](foo.md)
+    - [Bar](bar.md)
+  files:
+    foo.md: |
+      ## A
+
+      ## B
+
+      ## C
+    bar.md: |
+      ## D
+
+      ## E
+
+      ## F
+  want: |
+    ## Items
+
+    - [Foo](#foo)
+    - [Bar](#bar)
+
+    ### Foo
+
+    #### A
+
+    #### B
+
+    #### C
+
+    ### Bar
+
+    #### D
+
+    #### E
+
+    #### F


### PR DESCRIPTION
For pages that don't have a title (single h1 heading),
generate one.

If such a title is being generated
and all other headings in the page are h2 or higher,
leave them as-is

However, if the page doesn't have a title
because it has multiple h1 headings,
push them all down one level to make room for the new title.

Resolves #9