### PR TITLE
Page title must be the first element

### DIFF
--- a/collect.go
+++ b/collect.go
@@ -187,7 +187,11 @@ func (c *collector) collectFileItem(item *stitch.LinkItem) (*markdownFileItem, e
 		Headings:        headings,
 		HeadingsByOldID: headingsByOldID,
 	}
-	if len(h1s) == 1 {
+
+	// If the page has only one level 1 heading,
+	// and it's the first element in the page,
+	// then use it as the title.
+	if len(h1s) == 1 && h1s[0].AST.PreviousSibling() == nil {
 		mf.Title = h1s[0]
 	} else {
 		heading := ast.NewHeading(1)

--- a/testdata/integration/basic.yaml
+++ b/testdata/integration/basic.yaml
@@ -376,3 +376,40 @@
     #### E
 
     #### F
+
+- name: h1 is not first item
+  give: |
+    - [Foo](foo.md)
+    - [Bar](bar.md)
+  files:
+    foo.md: |
+      Foo is a thing.
+
+      # Details
+
+      Here are some details.
+    bar.md: |
+      Bar is another thing.
+
+      # Details
+
+      Here are some more details.
+  want: |
+    - [Foo](#foo)
+    - [Bar](#bar)
+
+    # Foo
+
+    Foo is a thing.
+
+    ## Details
+
+    Here are some details.
+
+    # Bar
+
+    Bar is another thing.
+
+    ## Details
+
+    Here are some more details.


### PR DESCRIPTION
For an h1 heading to be treated as the page title
it must be the first element in the document.

Resolves #5