### PR TITLE
Simplify page titling

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -65,16 +65,9 @@ func (g *generator) renderGroupItem(group *markdownGroupItem) error {
 		return err
 	}
 	io.WriteString(g.W, "\n")
-
 	return nil
 }
 
 func (g *generator) renderFileItem(file *markdownFileItem) error {
-	if t := file.TOCTitle; t != nil {
-		if err := g.Renderer.Render(g.W, file.File.Source, t.AST.Node); err != nil {
-			return err
-		}
-		io.WriteString(g.W, "\n\n")
-	}
 	return g.Renderer.Render(g.W, file.File.Source, file.File.AST.Node)
 }


### PR DESCRIPTION
Unconditionally generate a Title field on markdownFileItem,
and unconditionally prepend it to the document.

This further messes with the boundaries between collect and transform,
but it's overall positive.