### PR TITLE
collect: Reduce copying

### DIFF
--- a/collect.go
+++ b/collect.go
@@ -109,22 +109,19 @@ func (c *collector) collectItem(item stitch.Item) (markdownItem, error) {
 }
 
 type markdownFileItem struct {
-	// TOCLink is the original link in the TOC
+	// Path is the path to the Markdown file.
+	Path string
+
+	// Item is the original link in the TOC
 	// that referenced the Markdown file.
-	TOCLink *goldast.Link
-
-	// Depth is the depth at which the link was found in the TOC.
-	TOCDepth int
-
-	// File is the parsed Markdown file
-	// that the link points to.
-	File *goldast.File
+	Item *stitch.LinkItem
 
 	// Title is the title of the Markdown file, if any.
 	Title *markdownHeading
 
-	// Path is the path to the Markdown file.
-	Path string
+	// File is the parsed Markdown file
+	// that the link points to.
+	File *goldast.File
 
 	// Links holds all links that were found in the Markdown file.
 	Links []*goldast.Link
@@ -132,6 +129,8 @@ type markdownFileItem struct {
 	// Headings holds all headings that were found in the Markdown file.
 	Headings []*markdownHeading
 
+	// HeadingsByOldID maps IDs of headings, as interpreted in isolation.
+	// The IDs will change once interpreted as part of the combined document.
 	HeadingsByOldID map[string]*markdownHeading
 }
 
@@ -175,10 +174,9 @@ func (c *collector) collectFileItem(item *stitch.LinkItem) (*markdownFileItem, e
 	}
 
 	mf := &markdownFileItem{
-		TOCLink:         item.AST,
-		TOCDepth:        item.Depth,
-		File:            f,
 		Path:            item.Target,
+		Item:            item,
+		File:            f,
 		Links:           links,
 		Headings:        headings,
 		HeadingsByOldID: headingsByOldID,
@@ -217,9 +215,8 @@ func (c *collector) collectFileItem(item *stitch.LinkItem) (*markdownFileItem, e
 }
 
 type markdownGroupItem struct {
-	TOCText  *goldast.Text
-	TOCDepth int
-	Heading  *markdownHeading
+	Item    *stitch.TextItem
+	Heading *markdownHeading
 }
 
 func (*markdownGroupItem) markdownItem() {}
@@ -231,8 +228,7 @@ func (c *collector) collectGroupItem(item *stitch.TextItem) *markdownGroupItem {
 
 	id, _ := c.IDGen.GenerateID(item.Text)
 	return &markdownGroupItem{
-		TOCText:  item.AST,
-		TOCDepth: item.Depth,
+		Item: item,
 		Heading: &markdownHeading{
 			AST: goldast.WithPos(h, 0 /* never used */),
 			ID:  id,

--- a/transform.go
+++ b/transform.go
@@ -44,10 +44,10 @@ func (t *transformer) transformItem(item markdownItem) {
 }
 
 func (t *transformer) transformGroup(group *markdownGroupItem) {
-	group.Heading.AST.Node.Level += group.TOCDepth + t.sectionLevel
+	group.Heading.AST.Node.Level += group.Item.Depth + t.sectionLevel
 
 	// Replace "Foo" in the list with "[Foo](#foo)".
-	item := group.TOCText
+	item := group.Item.AST
 	parent := item.Node.Parent()
 
 	link := ast.NewLink()
@@ -59,11 +59,11 @@ func (t *transformer) transformGroup(group *markdownGroupItem) {
 
 func (t *transformer) transformFile(f *markdownFileItem) {
 	for _, h := range f.Headings {
-		h.AST.Node.Level += f.TOCDepth + t.sectionLevel
+		h.AST.Node.Level += f.Item.Depth + t.sectionLevel
 	}
 
-	if err := t.transformLink(".", f.TOCLink); err != nil {
-		t.Log.Printf("%v:%v", t.tocFile.Position(f.TOCLink.Pos()), err)
+	if err := t.transformLink(".", f.Item.AST); err != nil {
+		t.Log.Printf("%v:%v", t.tocFile.Position(f.Item.AST.Pos()), err)
 	}
 
 	dir := filepath.Dir(f.Path)


### PR DESCRIPTION
Don't copy information from items into collect types.
Just take the objects as-is.
