### PR TITLE
transform(link): Handle local fragment references

### DIFF
--- a/testdata/integration/header.yaml
+++ b/testdata/integration/header.yaml
@@ -1,0 +1,67 @@
+- name: collision
+  give: |
+    - [foo](foo.md)
+    - [bar](bar.md)
+  files:
+    foo.md: |
+      # Foo
+
+      ## Setup
+
+      See also [setting up bar](bar.md#setup).
+    bar.md: |
+      # Bar
+
+      ## Setup
+
+      See also [setting up foo](foo.md#setup).
+  want: |
+    - [foo](#foo)
+    - [bar](#bar)
+
+    # Foo
+
+    ## Setup
+
+    See also [setting up bar](#setup-1).
+
+    # Bar
+
+    ## Setup
+
+    See also [setting up foo](#setup).
+
+- name: local collision
+  give: |
+    - [foo](foo.md)
+    - [bar](bar.md)
+  files:
+    foo.md: |
+      # Foo
+
+      Taking over the Foo header.
+    bar.md: |
+      # Bar
+
+      See also [local foo](#foo)
+      and [external foo](foo.md#foo).
+
+      ## Foo
+
+      I collide with the other one.
+  want: |
+    - [foo](#foo)
+    - [bar](#bar)
+
+    # Foo
+
+    Taking over the Foo header.
+
+    # Bar
+
+    See also [local foo](#foo-1)
+    and [external foo](#foo).
+
+    ## Foo
+
+    I collide with the other one.

--- a/testdata/integration/link.yaml
+++ b/testdata/integration/link.yaml
@@ -70,39 +70,6 @@
 
     Set up Bar with these steps.
 
-- name: header collision
-  give: |
-    - [foo](foo.md)
-    - [bar](bar.md)
-  files:
-    foo.md: |
-      # Foo
-
-      ## Setup
-
-      See also [setting up bar](bar.md#setup).
-    bar.md: |
-      # Bar
-
-      ## Setup
-
-      See also [setting up foo](foo.md#setup).
-  want: |
-    - [foo](#foo)
-    - [bar](#bar)
-
-    # Foo
-
-    ## Setup
-
-    See also [setting up bar](#setup-1).
-
-    # Bar
-
-    ## Setup
-
-    See also [setting up foo](#setup).
-
 - name: out of scope file
   give: |
     - [foo](foo.md)

--- a/transform.go
+++ b/transform.go
@@ -67,15 +67,15 @@ func (t *transformer) transformFile(f *markdownFileItem) {
 		h.AST.Level += f.Item.Depth + t.sectionLevel
 	}
 
-	t.transformLink(".", f.Item.AST)
+	t.transformLink(".", f, f.Item.AST)
 
 	dir := filepath.Dir(f.Path)
 	for _, l := range f.Links {
-		t.transformLink(dir, l)
+		t.transformLink(dir, f, l)
 	}
 
 	for _, i := range f.Images {
-		t.transformImage(dir, i)
+		t.transformImage(dir, f, i)
 	}
 
 	doc := f.File.AST
@@ -86,38 +86,39 @@ func (t *transformer) transformFile(f *markdownFileItem) {
 	}
 }
 
-func (t *transformer) transformLink(fromDir string, link *ast.Link) {
-	link.Destination = []byte(t.transformURL(fromDir, string(link.Destination)))
+func (t *transformer) transformLink(fromDir string, f *markdownFileItem, link *ast.Link) {
+	link.Destination = []byte(t.transformURL(fromDir, f, string(link.Destination)))
 }
 
-func (t *transformer) transformImage(fromDir string, image *ast.Image) {
-	image.Destination = []byte(t.transformURL(fromDir, string(image.Destination)))
+func (t *transformer) transformImage(fromDir string, f *markdownFileItem, image *ast.Image) {
+	image.Destination = []byte(t.transformURL(fromDir, f, string(image.Destination)))
 }
 
-func (t *transformer) transformURL(fromDir, toURL string) string {
+func (t *transformer) transformURL(fromDir string, f *markdownFileItem, toURL string) string {
 	u, err := url.Parse(toURL)
 	if err != nil || u.Scheme != "" || u.Host != "" {
 		return toURL
 	}
 
-	if u.Path == "" {
-		// TODO: handle link to local header
-		return toURL
+	// Resolve the Path component of the URL to the destination file.
+	to := f
+	if u.Path != "" {
+		dst := filepath.Join(fromDir, u.Path)
+		var ok bool
+		to, ok = t.filesByPath[dst]
+		if !ok {
+			// This is a relative path that does not point to a Markdown
+			// file in the collection.
+			// It may be a link to a file in the input directory.
+			// Update the path and leave everything else as-is.
+			u.Path = path.Join(filepath.ToSlash(t.InputRelPath), dst)
+			return u.String()
+		}
+		u.Path = ""
 	}
 
-	dst := filepath.Join(fromDir, u.Path)
-	to, ok := t.filesByPath[dst]
-	if !ok {
-		// This is a relative path that does not point to a Markdown
-		// file in the collection.
-		// It may be a link to a file in the input directory.
-		u.Path = path.Join(filepath.ToSlash(t.InputRelPath), dst)
-		return u.String()
-	}
-
-	u.Path = ""
 	if u.Fragment != "" {
-		// If the fragment of a link to another Markdown file
+		// If the fragment of a link to a Markdown file
 		// is a known heading in that Markdown file,
 		// use the new ID of that header.
 		if h, ok := to.HeadingsByOldID[u.Fragment]; ok {


### PR DESCRIPTION
For local fragment references (e.g. `#foo`),
if they collide with other headers in the final document,
use the new header IDs.