### PR TITLE
goldast/Walk: Drop ErrSkip

### DIFF
--- a/internal/goldast/walk.go
+++ b/internal/goldast/walk.go
@@ -1,14 +1,6 @@
 package goldast
 
-import (
-	"errors"
-
-	"github.com/yuin/goldmark/ast"
-)
-
-// ErrSkip is returned by a [Visitor]
-// to indicate that the children of the current node should not be visited.
-var ErrSkip = errors.New("skip children")
+import "github.com/yuin/goldmark/ast"
 
 // Visitor visits individual nodes in a Goldmark AST.
 type Visitor func(ast.Node) error
@@ -24,9 +16,6 @@ func Walk(node ast.Node, fn Visitor) error {
 
 func walk(n ast.Node, visit Visitor) error {
 	if err := visit(n); err != nil {
-		if errors.Is(err, ErrSkip) {
-			err = nil
-		}
 		return err
 	}
 

--- a/internal/goldast/walk_test.go
+++ b/internal/goldast/walk_test.go
@@ -1,6 +1,7 @@
 package goldast
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -45,19 +46,23 @@ func TestWalk(t *testing.T) {
 	}
 }
 
-func TestWalkSkip(t *testing.T) {
+func TestWalk_error(t *testing.T) {
 	t.Parallel()
 
 	parser := goldmark.New().Parser()
 
+	giveErr := errors.New("great sadness")
 	f := Parse(parser, "foo.md", []byte("# Foo"))
 
 	var nodes []ast.Node
 	err := Walk(f.AST, func(n ast.Node) error {
+		if len(nodes) > 0 {
+			return giveErr
+		}
 		nodes = append(nodes, n)
-		return ErrSkip
+		return nil
 	})
-	require.NoError(t, err)
+	require.ErrorIs(t, err, giveErr)
 
 	require.Len(t, nodes, 1)
 	assert.IsType(t, new(ast.Document), nodes[0])


### PR DESCRIPTION
The skipping functionality isn't actually used.