### PR TITLE
goreleaser: --rm-dist is deprecated

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
       with:
         distribution: goreleaser
         version: latest
-        args: release --rm-dist --release-notes ${{ github.workspace }}-CHANGELOG.txt
+        args: release --clean --release-notes ${{ github.workspace }}-CHANGELOG.txt
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         AUR_KEY: ${{ secrets.AUR_KEY }}


### PR DESCRIPTION
During the last release, goreleaser reported that
the --rm-dist flag is deprecated
and we should use --clean instead.

```
• DEPRECATED: --rm-dist was deprecated in favor of --clean, check https://goreleaser.com/deprecations#-rm-dist for more details
```