### PR TITLE
goreleaser: Drop changelog skip

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -56,7 +56,3 @@ checksum:
 
 snapshot:
   name_template: "{{ incminor .Tag }}-dev"
-
-changelog:
-  # A commit log is not a changelog.
-  skip: true


### PR DESCRIPTION
Last N releases with goreleaser in different projects
did not include release notes in the GitHub Releases
despite the release notes flag.

From the log of the last release:

```
/opt/hostedtoolcache/goreleaser-action/1.15.2/x64/goreleaser release --rm-dist --release-notes /home/runner/work/stitchmd/stitchmd-CHANGELOG.txt
```

This is because `changelog.skip` was set to true.

```
changelog:
  # Set this to true if you don't want any changelog at all.
  # Warning: this will also ignore any changelog files passed via `--release-notes`,
  # and will render an empty changelog.
  # This may result in an empty release notes on GitHub/GitLab/Gitea.
  skip: true
```

