### PR TITLE
all: More tests, -o ensure directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Changed
+- `-o` now creates the output directory if it does not exist.
+
 ## v0.1.1 - 2023-02-25
 ### Fixed
 - Fix corner cases with text in the summary getting merged.

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ export GOBIN ?= $(dir $(abspath $(lastword $(MAKEFILE_LIST))))/bin
 export PATH := $(GOBIN):$(PATH)
 
 MODULES ?= . ./tools
-TEST_FLAGS ?= -v -race
+TEST_FLAGS ?= -race
 
 STATICCHECK = bin/staticcheck
 REVIVE = bin/revive

--- a/collect_test.go
+++ b/collect_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"testing"
+	"testing/fstest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.abhg.dev/stitchmd/internal/goldast"
+	"go.abhg.dev/stitchmd/internal/stitch"
+	"go.abhg.dev/stitchmd/internal/tree"
+)
+
+func TestCollector_fileDoesNotExist(t *testing.T) {
+	t.Parallel()
+
+	file := goldast.Parse(
+		goldast.DefaultParser(),
+		"stdin",
+		[]byte("- [foo](foo.md)"),
+	)
+	summary, err := stitch.ParseSummary(file)
+	require.NoError(t, err)
+
+	_, err = (&collector{
+		Parser: goldast.DefaultParser(),
+		FS:     make(fstest.MapFS), // empty filesystem
+	}).Collect(file.Info, summary)
+	require.Error(t, err)
+
+	assert.ErrorContains(t, err, "foo.md: file does not exist")
+}
+
+func TestCollector_unknownItemType(t *testing.T) {
+	t.Parallel()
+
+	type badItem struct {
+		stitch.Item
+	}
+
+	summary := &stitch.Summary{
+		Sections: []*stitch.Section{
+			{Items: tree.List[stitch.Item]{
+				{Value: badItem{}},
+			}},
+		},
+	}
+
+	assert.Panics(t, func() {
+		(&collector{
+			Parser: goldast.DefaultParser(),
+			FS:     make(fstest.MapFS),
+		}).Collect(fixedPositioner{Line: 1, Column: 1}, summary)
+	})
+}
+
+type fixedPositioner goldast.Position
+
+var _ goldast.Positioner = fixedPositioner{}
+
+func (p fixedPositioner) Position(offset int) goldast.Position {
+	return goldast.Position(p)
+}

--- a/flags_test.go
+++ b/flags_test.go
@@ -104,3 +104,39 @@ func TestCLIParser_Parse(t *testing.T) {
 		})
 	}
 }
+
+func TestFirstLineOf(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		desc string
+		give string
+		want string
+	}{
+		{desc: "empty"},
+		{
+			desc: "no newline",
+			give: "foo",
+			want: "foo",
+		},
+		{
+			desc: "single newline",
+			give: "foo\n",
+			want: "foo\n",
+		},
+		{
+			desc: "multiple newlines",
+			give: "foo\nbar\nbaz",
+			want: "foo\n",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, firstLineOf(tt.give))
+		})
+	}
+}

--- a/generate.go
+++ b/generate.go
@@ -16,9 +16,9 @@ type generator struct {
 	Log      *log.Logger
 }
 
-func (g *generator) Generate(coll *markdownCollection) error {
+func (g *generator) Generate(src []byte, coll *markdownCollection) error {
 	for _, sec := range coll.Sections {
-		if err := g.renderSection(coll.TOCFile.Source, sec); err != nil {
+		if err := g.renderSection(src, sec); err != nil {
 			return err
 		}
 		if err := sec.Items.Walk(g.renderItem); err != nil {

--- a/integration_test.go
+++ b/integration_test.go
@@ -60,7 +60,6 @@ func TestIntegration(t *testing.T) {
 			output := filepath.Join(dir, "output.md")
 			if tt.OutDir != "" {
 				outDir := filepath.FromSlash(tt.OutDir)
-				require.NoError(t, os.MkdirAll(filepath.Join(dir, outDir), 0o755))
 				output = filepath.Join(dir, outDir, "output.md")
 			}
 

--- a/internal/goldast/err.go
+++ b/internal/goldast/err.go
@@ -11,9 +11,7 @@ import (
 // ErrorList tracks errors associated with positions of ast.Nodes in a
 // document.
 type ErrorList struct {
-	info interface {
-		Position(int) Position
-	}
+	info Positioner
 	errs []*posError
 
 	// Reports the position of the given node.
@@ -23,14 +21,11 @@ type ErrorList struct {
 
 // NewErrorList builds an ErrorList
 // that uses the provided [pos.Info] to report positions.
-func NewErrorList(info *Info) *ErrorList {
+func NewErrorList(info Positioner) *ErrorList {
 	return newErrorList(info, OffsetOf)
 }
 
-func newErrorList(
-	info interface{ Position(int) Position },
-	offsetOf func(ast.Node) int,
-) *ErrorList {
+func newErrorList(info Positioner, offsetOf func(ast.Node) int) *ErrorList {
 	return &ErrorList{info: info, offsetOf: offsetOf}
 }
 

--- a/internal/goldast/pos.go
+++ b/internal/goldast/pos.go
@@ -28,6 +28,13 @@ func (p Position) String() string {
 	return string(bs)
 }
 
+// Positioner reports the position of a given offset in a file.
+type Positioner interface {
+	Position(offset int) Position
+}
+
+var _ Positioner = (*Info)(nil)
+
 // Info holds richer position information.
 // It can be used to convert a Pos to a human-readable Position.
 type Info struct {

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMain_badFlag(t *testing.T) {
+	t.Parallel()
+
+	var stderr bytes.Buffer
+	exitCode := (&mainCmd{
+		Stdin:  bytes.NewReader(nil),
+		Stdout: io.Discard,
+		Stderr: &stderr,
+		Getwd:  os.Getwd,
+	}).Run([]string{"--flag-does-not-exist"})
+
+	assert.Equal(t, 1, exitCode)
+	assert.Contains(t, stderr.String(),
+		"flag provided but not defined: -flag-does-not-exist")
+}
+
+func TestMain_helpFlag(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	exitCode := (&mainCmd{
+		Stdin:  bytes.NewReader(nil),
+		Stdout: &stdout,
+		Stderr: io.Discard,
+		Getwd:  os.Getwd,
+	}).Run([]string{"--help"})
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout.String(), _usage)
+}
+
+func TestMain_versionFlag(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	exitCode := (&mainCmd{
+		Stdin:  bytes.NewReader(nil),
+		Stdout: &stdout,
+		Stderr: io.Discard,
+		Getwd:  os.Getwd,
+	}).Run([]string{"--version"})
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout.String(), _version)
+}
+
+func TestMain_summaryDoesNotExist(t *testing.T) {
+	t.Parallel()
+
+	var stderr bytes.Buffer
+	exitCode := (&mainCmd{
+		Stdin:  bytes.NewReader(nil),
+		Stdout: io.Discard,
+		Stderr: &stderr,
+		Getwd:  os.Getwd,
+	}).Run([]string{"does-not-exist.md"})
+
+	assert.Equal(t, 1, exitCode)
+	assertNoSuchFileError(t, stderr.String())
+}
+
+func TestMain_cwdError(t *testing.T) {
+	t.Parallel()
+
+	var stderr bytes.Buffer
+	exitCode := (&mainCmd{
+		Stdin:  bytes.NewReader(nil),
+		Stdout: io.Discard,
+		Stderr: &stderr,
+		Getwd: func() (string, error) {
+			return "", os.ErrPermission
+		},
+	}).Run([]string{"-"})
+
+	assert.Equal(t, 1, exitCode)
+	assert.Contains(t, stderr.String(), "permission denied")
+}
+
+func TestMain_badSummary(t *testing.T) {
+	t.Parallel()
+
+	var stderr bytes.Buffer
+	exitCode := (&mainCmd{
+		Stdin:  bytes.NewReader([]byte("great sadness")),
+		Stdout: io.Discard,
+		Stderr: &stderr,
+		Getwd:  os.Getwd,
+	}).Run([]string{"-"})
+
+	assert.Equal(t, 1, exitCode)
+	assert.Contains(t, stderr.String(), "1:1:expected a list or heading")
+	assert.Contains(t, stderr.String(), "error parsing summary")
+}
+
+func TestMain_summaryItemDoesNotExist(t *testing.T) {
+	t.Parallel()
+
+	var stderr bytes.Buffer
+	exitCode := (&mainCmd{
+		Stdin:  bytes.NewReader([]byte("- [does-not-exist](does-not-exist.md)")),
+		Stdout: io.Discard,
+		Stderr: &stderr,
+		Getwd:  os.Getwd,
+	}).Run([]string{"-"})
+	assert.Equal(t, 1, exitCode)
+	assertNoSuchFileError(t, stderr.String())
+	assert.Contains(t, stderr.String(), "error reading markdown")
+}
+
+func assertNoSuchFileError(t *testing.T, str string) {
+	t.Helper()
+
+	if runtime.GOOS == "windows" {
+		assert.Contains(t, str, "The system cannot find the file specified.")
+	} else {
+		assert.Contains(t, str, "no such file or directory")
+	}
+}

--- a/testdata/integration/link.yaml
+++ b/testdata/integration/link.yaml
@@ -138,3 +138,31 @@
     ![graph](../static/graph.png)
 
     See also [baz](../in/baz/qux.md).
+
+- name: invalid URL
+  give: |
+    - [Foo](foo.md)
+  files:
+    foo.md: |
+      Stuff about foo.
+      [Bad URL escape](https://example.com/foo%LOL).
+  want: |
+    - [Foo](#foo)
+
+    # Foo
+
+    Stuff about foo.
+    [Bad URL escape](https://example.com/foo%LOL).
+
+- name: external URL
+  give: |
+    - [Bar](bar.md)
+  files:
+    bar.md: |
+      Check out [example](https://example.com/foo.md).
+  want: |
+    - [Bar](#bar)
+
+    # Bar
+
+    Check out [example](https://example.com/foo.md).

--- a/transform.go
+++ b/transform.go
@@ -7,7 +7,6 @@ import (
 	"path"
 
 	"github.com/yuin/goldmark/ast"
-	"go.abhg.dev/stitchmd/internal/goldast"
 )
 
 type transformer struct {
@@ -21,11 +20,9 @@ type transformer struct {
 	sectionLevel int
 
 	filesByPath map[string]*markdownFileItem
-	tocFile     *goldast.File
 }
 
 func (t *transformer) Transform(coll *markdownCollection) {
-	t.tocFile = coll.TOCFile
 	t.filesByPath = coll.FilesByPath
 	for _, sec := range coll.Sections {
 		t.sectionLevel = sec.TitleLevel()


### PR DESCRIPTION
Add more test cases for various previously uncovered cases.
This uncovered a slightly behavior annoyance:
`-o` fails if a directory does not exist.
It makes for a better UX if we just ensure that the directory exists.