### PR TITLE
Add -offset flag to offset headings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- `-offset N` flag to offset all headings by a fixed amount
+  (positive or negative).
+
 ### Changed
 - `-o` now creates the output directory if it does not exist.
 

--- a/README.md
+++ b/README.md
@@ -375,6 +375,7 @@ will be roughly in the following shape:
 
 stitchmd supports the following options:
 
+- [`-offset N`](#offset-heading-levels)
 - [`-o FILE`](#write-to-file)
 - [`-C DIR`](#change-the-directory)
 
@@ -385,6 +386,31 @@ you can pass in '-' as the file name to read the summary from stdin.
 
 ```bash
 cat summary.md | stitchmd -
+```
+
+#### Offset heading levels
+
+stitchmd changes heading levels based on a few factors:
+
+- level of the section heading
+- position of the file in the hierarchy of that section
+- the file's own title heading
+
+The `-offset` flag allows you to offset all these headings.
+
+For example, the following will push all headings one level down,
+so what would normally be level 3 will now be level 4.
+
+```bash
+stitchmd -offset 1 summary.md
+```
+
+This number may be negative to reduce heading levels.
+For example, the following will turn
+what would normally be a level 3 heading into a level 2 heading.
+
+```bash
+stitchmd -offset -1 summary.md
 ```
 
 #### Write to file

--- a/collect.go
+++ b/collect.go
@@ -52,13 +52,6 @@ type markdownSection struct {
 	Items    tree.List[markdownItem]
 }
 
-func (s *markdownSection) TitleLevel() int {
-	if s.Title != nil {
-		return s.Title.Level
-	}
-	return 0
-}
-
 func (c *collector) collectSection(errs *goldast.ErrorList, sec *stitch.Section) *markdownSection {
 	items := tree.TransformList(sec.Items, func(item stitch.Item) markdownItem {
 		i, err := c.collectItem(item)

--- a/doc/options.md
+++ b/doc/options.md
@@ -2,6 +2,7 @@
 
 stitchmd supports the following options:
 
+- [`-offset N`](#offset-heading-levels)
 - [`-o FILE`](#write-to-file)
 - [`-C DIR`](#change-the-directory)
 
@@ -12,6 +13,31 @@ you can pass in '-' as the file name to read the summary from stdin.
 
 ```bash
 cat summary.md | stitchmd -
+```
+
+## Offset heading levels
+
+stitchmd changes heading levels based on a few factors:
+
+- level of the section heading
+- position of the file in the hierarchy of that section
+- the file's own title heading
+
+The `-offset` flag allows you to offset all these headings.
+
+For example, the following will push all headings one level down,
+so what would normally be level 3 will now be level 4.
+
+```bash
+stitchmd -offset 1 summary.md
+```
+
+This number may be negative to reduce heading levels.
+For example, the following will turn
+what would normally be a level 3 heading into a level 2 heading.
+
+```bash
+stitchmd -offset -1 summary.md
 ```
 
 ## Write to file

--- a/flags.go
+++ b/flags.go
@@ -20,6 +20,7 @@ type params struct {
 	Input  string // defaults to stdin
 	Output string // defaults to stdout
 	Dir    string
+	Offset int
 }
 
 // cliParser parses command line arguments.
@@ -41,6 +42,7 @@ func (p *cliParser) newFlagSet() (*params, *flag.FlagSet) {
 	var opts params
 	flag.StringVar(&opts.Output, "o", "", "")
 	flag.StringVar(&opts.Dir, "C", "", "")
+	flag.IntVar(&opts.Offset, "offset", 0, "")
 
 	flag.BoolVar(&p.version, "version", false, "")
 	flag.BoolVar(&p.help, "help", false, "")

--- a/flags_test.go
+++ b/flags_test.go
@@ -69,6 +69,16 @@ func TestCLIParser_Parse(t *testing.T) {
 			want: params{Output: "", Input: "bar"},
 		},
 		{
+			desc: "offset",
+			args: []string{"-offset", "2", "bar"},
+			want: params{Offset: 2, Input: "bar"},
+		},
+		{
+			desc: "offset/negative",
+			args: []string{"-offset", "-2", "bar"},
+			want: params{Offset: -2, Input: "bar"},
+		},
+		{
 			desc:    "too many args",
 			args:    []string{"-o", "foo", "bar", "baz"},
 			wantErr: "unexpected arguments:",

--- a/integration_test.go
+++ b/integration_test.go
@@ -22,6 +22,9 @@ func TestIntegration(t *testing.T) {
 		Files map[string]string `yaml:"files"`
 		Want  string            `yaml:"want"`
 
+		// Heading offset.
+		Offset int `yaml:"offset"`
+
 		// Path to the output directory,
 		// relative to the test directory.
 		OutDir string `yaml:"outDir"`
@@ -89,6 +92,7 @@ func TestIntegration(t *testing.T) {
 			require.NoError(t, cmd.run(&params{
 				Input:  input,
 				Output: output,
+				Offset: tt.Offset,
 			}))
 
 			got, err := os.ReadFile(output)

--- a/internal/stitch/item_test.go
+++ b/internal/stitch/item_test.go
@@ -1,0 +1,37 @@
+package stitch
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/yuin/goldmark/ast"
+)
+
+func TestLinkItem_accessors(t *testing.T) {
+	t.Parallel()
+
+	link := ast.NewLink()
+	item := LinkItem{
+		Text:   "foo",
+		Target: "foo.md",
+		Depth:  3,
+		AST:    link,
+	}
+
+	assert.Equal(t, 3, item.ItemDepth())
+	assert.True(t, item.Node() == link)
+}
+
+func TestTextItem_accessors(t *testing.T) {
+	t.Parallel()
+
+	node := ast.NewText()
+	item := TextItem{
+		Text:  "foo",
+		Depth: 3,
+		AST:   node,
+	}
+
+	assert.Equal(t, 3, item.ItemDepth())
+	assert.True(t, item.Node() == node)
+}

--- a/main.go
+++ b/main.go
@@ -157,6 +157,7 @@ func (cmd *mainCmd) run(opts *params) error {
 
 	(&transformer{
 		Log:          log,
+		Offset:       opts.Offset,
 		InputRelPath: filepath.ToSlash(inputRel),
 	}).Transform(coll)
 

--- a/testdata/integration/offset.yaml
+++ b/testdata/integration/offset.yaml
@@ -1,0 +1,108 @@
+- name: positive
+  offset: 2
+  give: |
+    # Foo
+
+    - [Bar](bar.md)
+  files:
+    bar.md: |
+      # Bar
+
+      ## Baz
+  want: |
+    ### Foo
+
+    - [Bar](#bar)
+
+    #### Bar
+
+    ##### Baz
+
+- name: positive/no section title
+  offset: 2
+  give: |
+    - [Foo](foo.md)
+  files:
+    foo.md: |
+      # Foo
+
+      ## Bar
+  want: |
+    - [Foo](#foo)
+
+    ### Foo
+
+    #### Bar
+
+- name: negative
+  offset: -2
+  give: |
+    # Unchanged
+
+    - [Bar](bar.md)
+  files:
+    bar.md: |
+      # Bar
+
+      ## Baz
+
+      ### Qux
+  want: |
+    # Unchanged
+
+    - [Bar](#bar)
+
+    # Bar
+
+    # Baz
+
+    ## Qux
+
+- name: negative/section title
+  offset: -2
+  give: |
+    #### Foo
+
+    - Bar
+      - Baz
+        - [Qux](qux.md)
+  files:
+    qux.md: "# Qux"
+  want: |
+    ## Foo
+
+    - [Bar](#bar)
+      - [Baz](#baz)
+        - [Qux](#qux)
+
+    ### Bar
+
+    #### Baz
+
+    ##### Qux
+
+- name: negative/no section
+  offset: -1
+  give: |
+    - Foo
+      - [Bar](bar.md)
+  files:
+    bar.md: |
+      # A
+
+      # B
+
+      # C
+  want: |
+    - [Foo](#foo)
+      - [Bar](#bar)
+
+    # Foo
+
+    # Bar
+
+    ## A
+
+    ## B
+
+    ## C

--- a/usage.txt
+++ b/usage.txt
@@ -6,6 +6,9 @@ Reads from stdin if FILE is '-'.
 
 OPTIONS
 
+  -offset N
+	base offset for heading levels.
+	May be negative to increase heading levels.
   -o FILE
 	write output to FILE instead of stdout.
   -C DIR


### PR DESCRIPTION
Adds a new `-offset` flag that, if specified,
offsets all headings by the specified amount.
Anything below one is normalized to one.

Resolves #12