### PR TITLE
Add -no-toc flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `-offset N` flag to offset all headings by a fixed amount
   (positive or negative).
+- `-no-toc` flag to stop the table of contents from being rendered
+  in the output.
 
 ### Changed
 - `-o` now creates the output directory if it does not exist.

--- a/README.md
+++ b/README.md
@@ -376,6 +376,7 @@ will be roughly in the following shape:
 stitchmd supports the following options:
 
 - [`-offset N`](#offset-heading-levels)
+- [`-no-toc`](#disable-the-toc)
 - [`-o FILE`](#write-to-file)
 - [`-C DIR`](#change-the-directory)
 
@@ -471,6 +472,49 @@ stitchmd -offset -1 summary.md
 ## Installation
 
 <!-- ... -->
+```
+
+</details>
+
+#### Disable the TOC
+
+```
+-no-toc
+```
+
+stitchmd reproduces the original table of contents in the output.
+You can change this with the `-no-toc` flag.
+
+```bash
+stitchmd -no-toc summary.md
+```
+
+This will omit the item listing under each section.
+
+<details>
+<summary>Example</summary>
+
+**Input**
+
+```markdown
+- [Introduction](intro.md)
+- [Installation](install.md)
+```
+
+```bash
+stitchmd -no-toc summary.md
+```
+
+**Output**
+
+```markdown
+# Introduction
+
+<!-- .. -->
+
+# Installation
+
+<!-- .. -->
 ```
 
 </details>

--- a/doc/options.md
+++ b/doc/options.md
@@ -3,6 +3,7 @@
 stitchmd supports the following options:
 
 - [`-offset N`](#offset-heading-levels)
+- [`-no-toc`](#disable-the-toc)
 - [`-o FILE`](#write-to-file)
 - [`-C DIR`](#change-the-directory)
 
@@ -98,6 +99,49 @@ stitchmd -offset -1 summary.md
 ## Installation
 
 <!-- ... -->
+```
+
+</details>
+
+## Disable the TOC
+
+```
+-no-toc
+```
+
+stitchmd reproduces the original table of contents in the output.
+You can change this with the `-no-toc` flag.
+
+```bash
+stitchmd -no-toc summary.md
+```
+
+This will omit the item listing under each section.
+
+<details>
+<summary>Example</summary>
+
+**Input**
+
+```markdown
+- [Introduction](intro.md)
+- [Installation](install.md)
+```
+
+```bash
+stitchmd -no-toc summary.md
+```
+
+**Output**
+
+```markdown
+# Introduction
+
+<!-- .. -->
+
+# Installation
+
+<!-- .. -->
 ```
 
 </details>

--- a/flags.go
+++ b/flags.go
@@ -21,6 +21,7 @@ type params struct {
 	Output string // defaults to stdout
 	Dir    string
 	Offset int
+	NoTOC  bool
 }
 
 // cliParser parses command line arguments.
@@ -43,6 +44,7 @@ func (p *cliParser) newFlagSet() (*params, *flag.FlagSet) {
 	flag.StringVar(&opts.Output, "o", "", "")
 	flag.StringVar(&opts.Dir, "C", "", "")
 	flag.IntVar(&opts.Offset, "offset", 0, "")
+	flag.BoolVar(&opts.NoTOC, "no-toc", false, "")
 
 	flag.BoolVar(&p.version, "version", false, "")
 	flag.BoolVar(&p.help, "help", false, "")

--- a/flags_test.go
+++ b/flags_test.go
@@ -79,6 +79,21 @@ func TestCLIParser_Parse(t *testing.T) {
 			want: params{Offset: -2, Input: "bar"},
 		},
 		{
+			desc: "no-toc",
+			args: []string{"-no-toc", "bar"},
+			want: params{NoTOC: true, Input: "bar"},
+		},
+		{
+			desc: "no-toc/explicit true",
+			args: []string{"-no-toc=true", "bar"},
+			want: params{NoTOC: true, Input: "bar"},
+		},
+		{
+			desc: "no-toc/explicit false",
+			args: []string{"-no-toc=false", "bar"},
+			want: params{NoTOC: false, Input: "bar"},
+		},
+		{
 			desc:    "too many args",
 			args:    []string{"-o", "foo", "bar", "baz"},
 			wantErr: "unexpected arguments:",

--- a/generate.go
+++ b/generate.go
@@ -14,6 +14,7 @@ type generator struct {
 	W        io.Writer
 	Renderer *mdfmt.Renderer
 	Log      *log.Logger
+	NoTOC    bool
 }
 
 func (g *generator) Generate(src []byte, coll *markdownCollection) error {
@@ -29,16 +30,24 @@ func (g *generator) Generate(src []byte, coll *markdownCollection) error {
 }
 
 func (g *generator) renderSection(src []byte, sec *markdownSection) error {
+	empty := true
 	if t := sec.Title; t != nil {
+		empty = false
 		if err := g.Renderer.Render(g.W, src, t); err != nil {
 			return err
 		}
 	}
 
-	if err := g.Renderer.Render(g.W, src, sec.TOCItems); err != nil {
-		return err
+	if !g.NoTOC {
+		empty = false
+		if err := g.Renderer.Render(g.W, src, sec.TOCItems); err != nil {
+			return err
+		}
 	}
-	io.WriteString(g.W, "\n\n")
+
+	if !empty {
+		io.WriteString(g.W, "\n\n")
+	}
 	return nil
 }
 

--- a/integration_test.go
+++ b/integration_test.go
@@ -22,8 +22,8 @@ func TestIntegration(t *testing.T) {
 		Files map[string]string `yaml:"files"`
 		Want  string            `yaml:"want"`
 
-		// Heading offset.
-		Offset int `yaml:"offset"`
+		Offset int  `yaml:"offset"` // -offset
+		NoTOC  bool `yaml:"no-toc"` // -no-toc
 
 		// Path to the output directory,
 		// relative to the test directory.
@@ -93,6 +93,7 @@ func TestIntegration(t *testing.T) {
 				Input:  input,
 				Output: output,
 				Offset: tt.Offset,
+				NoTOC:  tt.NoTOC,
 			}))
 
 			got, err := os.ReadFile(output)

--- a/main.go
+++ b/main.go
@@ -170,6 +170,7 @@ func (cmd *mainCmd) run(opts *params) error {
 		W:        output,
 		Renderer: render,
 		Log:      log,
+		NoTOC:    opts.NoTOC,
 	}
 	return g.Generate(f.Source, coll)
 }

--- a/testdata/integration/no_toc.yaml
+++ b/testdata/integration/no_toc.yaml
@@ -1,0 +1,80 @@
+- name: single
+  no-toc: true
+  give: |
+    # Foo
+
+    - [Bar](bar.md)
+      - [Baz](baz.md)
+    - [Qux](qux.md)
+  files:
+    bar.md: "# Bar"
+    baz.md: "# Baz"
+    qux.md: "# Qux"
+  want: |
+    # Foo
+
+    ## Bar
+
+    ### Baz
+
+    ## Qux
+
+- name: auto-header
+  no-toc: true
+  give: |
+    # Foo
+
+    - [Bar](bar.md)
+      - [Baz](baz.md)
+    - [Qux](qux.md)
+  files:
+    bar.md: "bar"
+    baz.md: "baz"
+    qux.md: "qux"
+  want: |
+    # Foo
+
+    ## Bar
+
+    bar
+
+    ### Baz
+
+    baz
+
+    ## Qux
+
+    qux
+
+- name: no section title
+  no-toc: true
+  give: |
+    - [Bar](bar.md)
+      - [Baz](baz.md)
+    - [Qux](qux.md)
+  files:
+    bar.md: "# Bar"
+    baz.md: "# Baz"
+    qux.md: "# Qux"
+  want: |
+    # Bar
+
+    ## Baz
+
+    # Qux
+
+- name: group header
+  no-toc: true
+  give: |
+    - Bar
+      - [Baz](baz.md)
+      - [Qux](qux.md)
+  files:
+    baz.md: "# Baz"
+    qux.md: "# Qux"
+  want: |
+    # Bar
+
+    ## Baz
+
+    ## Qux

--- a/usage.txt
+++ b/usage.txt
@@ -9,6 +9,8 @@ OPTIONS
   -offset N
 	base offset for heading levels.
 	May be negative to increase heading levels.
+  -no-toc
+	don't generate a table of contents under each section.
   -o FILE
 	write output to FILE instead of stdout.
   -C DIR


### PR DESCRIPTION
Adds a -no-toc flag that disables reproducing the original TOC
under each section.

Resolves #6