### PR TITLE
feat: -d flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+- `-d` flag to print a diff of the output
+  instead of writing to the output file.
+
 ## v0.2.0 - 2023-02-26
 ### Added
 - `-offset N` flag to offset all headings by a fixed amount

--- a/Makefile
+++ b/Makefile
@@ -70,9 +70,8 @@ fmtcheck:
 	fi
 
 .PHONY: readmecheck
-readmecheck:
-	make readme
-	@DIFF=$$(git diff README.md); \
+readmecheck: $(STITCHMD)
+	@DIFF=$$($(STITCHMD) -d -o README.md doc/README.md); \
 	if [[ -n "$$DIFF" ]]; then \
 		echo "README.md is out of date:"; \
 		echo "$$DIFF"; \

--- a/README.md
+++ b/README.md
@@ -379,6 +379,7 @@ stitchmd supports the following options:
 - [`-no-toc`](#disable-the-toc)
 - [`-o FILE`](#write-to-file)
 - [`-C DIR`](#change-the-directory)
+- [`-d`](#report-a-diff)
 
 #### Read from stdin
 
@@ -554,6 +555,25 @@ This is especially useful if your summary file is
 ```bash
 ... | stitchmd -C docs -
 ```
+
+#### Report a diff
+
+```
+-d
+```
+
+stitchmd normally writes output directly to the file
+if you pass in a filename with [`-o`](#write-to-file).
+Use the `-d` flag to instead have it report what would change
+in the output file without actually changing it.
+
+```bash
+stitchmd -d -o README.md # ...
+```
+
+This can be useful for lint checks and similar,
+or to do a dry run and find out what would change
+without changing it.
 
 ### Syntax
 

--- a/doc/options.md
+++ b/doc/options.md
@@ -6,6 +6,7 @@ stitchmd supports the following options:
 - [`-no-toc`](#disable-the-toc)
 - [`-o FILE`](#write-to-file)
 - [`-C DIR`](#change-the-directory)
+- [`-d`](#report-a-diff)
 
 ## Read from stdin
 
@@ -181,3 +182,22 @@ This is especially useful if your summary file is
 ```bash
 ... | stitchmd -C docs -
 ```
+
+## Report a diff
+
+```
+-d
+```
+
+stitchmd normally writes output directly to the file
+if you pass in a filename with [`-o`](#write-to-file).
+Use the `-d` flag to instead have it report what would change
+in the output file without actually changing it.
+
+```bash
+stitchmd -d -o README.md # ...
+```
+
+This can be useful for lint checks and similar,
+or to do a dry run and find out what would change
+without changing it.

--- a/flags.go
+++ b/flags.go
@@ -22,6 +22,8 @@ type params struct {
 	Dir    string
 	Offset int
 	NoTOC  bool
+
+	Diff bool
 }
 
 // cliParser parses command line arguments.
@@ -45,6 +47,7 @@ func (p *cliParser) newFlagSet() (*params, *flag.FlagSet) {
 	flag.StringVar(&opts.Dir, "C", "", "")
 	flag.IntVar(&opts.Offset, "offset", 0, "")
 	flag.BoolVar(&opts.NoTOC, "no-toc", false, "")
+	flag.BoolVar(&opts.Diff, "d", false, "")
 
 	flag.BoolVar(&p.version, "version", false, "")
 	flag.BoolVar(&p.help, "help", false, "")
@@ -99,6 +102,13 @@ func (p *cliParser) Parse(args []string) (*params, cliParseResult) {
 	}
 	if opts.Output == "-" {
 		opts.Output = ""
+	}
+
+	// Reject -d if -o is not set.
+	if opts.Diff && opts.Output == "" {
+		fmt.Fprintln(p.Stderr, "cannot use -d without -o")
+		fset.Usage()
+		return nil, cliParseError
 	}
 
 	return opts, cliParseSuccess

--- a/flags_test.go
+++ b/flags_test.go
@@ -94,6 +94,21 @@ func TestCLIParser_Parse(t *testing.T) {
 			want: params{NoTOC: false, Input: "bar"},
 		},
 		{
+			desc: "diff",
+			args: []string{"-d", "-o", "foo", "bar"},
+			want: params{
+				Diff:   true,
+				Output: "foo",
+				Input:  "bar",
+			},
+		},
+		{
+			desc:    "diff/missing o",
+			args:    []string{"-d", "bar"},
+			wantRes: cliParseError,
+			wantErr: "cannot use -d without -o",
+		},
+		{
 			desc:    "too many args",
 			args:    []string{"-o", "foo", "bar", "baz"},
 			wantErr: "unexpected arguments:",

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.20
 
 require (
 	github.com/Kunde21/markdownfmt/v3 v3.1.0
+	github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e
 	github.com/stretchr/testify v1.8.2
 	github.com/yuin/goldmark v1.5.4
 	github.com/yuin/goldmark-meta v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
+github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e h1:aoZm08cpOy4WuID//EZDgcC4zIxODThtZNPirFr42+A=
+github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/testdata/diff.yaml
+++ b/testdata/diff.yaml
@@ -1,0 +1,53 @@
+- name: no changes
+  give: |
+    - [foo](foo.md)
+    - [bar](bar.md)
+  files:
+    foo.md: "# Foo"
+    bar.md: "# Bar"
+  old: |
+    - [foo](#foo)
+    - [bar](#bar)
+
+    # Foo
+
+    # Bar
+  diff: ""
+
+- name: old does not exist
+  give: |
+    - [foo](foo.md)
+    - [bar](bar.md)
+  files:
+    foo.md: "# Foo"
+    bar.md: "# Bar"
+  diff: |
+    @@ -0,0 +1,6 @@
+    +- [foo](#foo)
+    +- [bar](#bar)
+    +
+    +# Foo
+    +
+    +# Bar
+
+- name: some changes
+  give: |
+    - [foo](foo.md)
+    - [bar](bar.md)
+  files:
+    foo.md: "# Foo"
+    bar.md: "# Bar"
+  old: |
+    - [foo](#foo)
+    - [bar](#bar)
+
+    # Bar
+  diff: |
+    @@ -1,4 +1,6 @@
+     - [foo](#foo)
+     - [bar](#bar)
+     
+    +# Foo
+    +
+     # Bar
+

--- a/usage.txt
+++ b/usage.txt
@@ -17,6 +17,8 @@ OPTIONS
 	change to DIR before reading files.
 	Defaults to the directory of FILE, or the current directory if reading
 	from stdin.
+  -d	report a diff of the output to stdout instead of writing to the file.
+	This is valid only if -o is also specified.
   -version
 	print version information.
   -h, -help


### PR DESCRIPTION
Adds a new flag -d that, with -o, reports a diff between
the output file and what would be generated by the tool.
It does not change anything on-disk.

This can be used in CI checks and the like
to ensure that the file is up-to-date.