### PR TITLE
-d: Add -diff alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- `-diff` flag as an alias for `-d`.
+
 ### Changed
 - The output of `-d` is now colored by default if stdout is a terminal.
   Disable with `--color=never`, or by setting `NO_COLOR=1`.

--- a/flags.go
+++ b/flags.go
@@ -49,8 +49,9 @@ func (p *cliParser) newFlagSet() (*params, *flag.FlagSet) {
 	flag.StringVar(&opts.Dir, "C", "", "")
 	flag.IntVar(&opts.Offset, "offset", 0, "")
 	flag.BoolVar(&opts.NoTOC, "no-toc", false, "")
-	flag.BoolVar(&opts.Diff, "d", false, "")
 	flag.Var(&opts.ColorOutput, "color", "")
+	flag.BoolVar(&opts.Diff, "d", false, "")
+	flag.BoolVar(&opts.Diff, "diff", false, "")
 
 	flag.BoolVar(&p.version, "version", false, "")
 	flag.BoolVar(&p.help, "help", false, "")

--- a/flags_test.go
+++ b/flags_test.go
@@ -114,6 +114,15 @@ func TestCLIParser_Parse(t *testing.T) {
 			},
 		},
 		{
+			desc: "diff alias",
+			args: []string{"-diff", "-o", "foo", "bar"},
+			want: params{
+				Diff:   true,
+				Output: "foo",
+				Input:  "bar",
+			},
+		},
+		{
 			desc:    "diff/missing o",
 			args:    []string{"-d", "bar"},
 			wantRes: cliParseError,

--- a/usage.txt
+++ b/usage.txt
@@ -17,7 +17,8 @@ OPTIONS
 	change to DIR before reading files.
 	Defaults to the directory of FILE, or the current directory if reading
 	from stdin.
-  -d	report a diff of the output to stdout instead of writing to the file.
+  -d, -diff
+	report a diff of the output to stdout instead of writing to the file.
 	This is valid only if -o is also specified.
   -color [always|never|auto]
 	whether to use color in the command output. Defaults to 'auto'.


### PR DESCRIPTION
I found myself typing -diff more often than -d.
It makes sense to have a long form alias for the flag.