### PR TITLE
feat: Support external links in summary

### DIFF
--- a/.changes/unreleased/Added-20230423-220030.yaml
+++ b/.changes/unreleased/Added-20230423-220030.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Support external links in summary. These will be rendered verbatim.
+time: 2023-04-23T22:00:30.535393314-07:00

--- a/README.md
+++ b/README.md
@@ -717,6 +717,19 @@ to indicate a hierarchy.
   ```
     </details>
 
+- **External links**:
+  These will be written in the generated table-of-contents verbatim.
+  They cannot have other items nested inside them.
+
+    <details>
+    <summary>Example</summary>
+
+  ```markdown
+  - [Overview](overview.md)
+  - [Community](https://example.com)
+  ```
+    </details>
+
 Items listed in a section are rendered together under that section.
 A section is rendered in its entirety
 before the listing for the next section begins.

--- a/doc/syntax.md
+++ b/doc/syntax.md
@@ -59,6 +59,19 @@ to indicate a hierarchy.
     ```
     </details>
 
+- **External links**:
+  These will be written in the generated table-of-contents verbatim.
+  They cannot have other items nested inside them.
+
+    <details>
+    <summary>Example</summary>
+
+    ```markdown
+    - [Overview](overview.md)
+    - [Community](https://example.com)
+    ```
+    </details>
+
 
 Items listed in a section are rendered together under that section.
 A section is rendered in its entirety

--- a/internal/stitch/summary_test.go
+++ b/internal/stitch/summary_test.go
@@ -145,6 +145,13 @@ func TestParseSummary(t *testing.T) {
 						linkItem(1, "baz", "baz.md"))),
 			),
 		},
+		{
+			desc: "external link",
+			give: "- [foo](https://example.com)",
+			want: toc(
+				section(0, "", linkItem(0, "foo", "https://example.com")),
+			),
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/tree/node.go
+++ b/internal/tree/node.go
@@ -13,9 +13,9 @@ type Node[T any] struct {
 // Transform creates a new node
 // by transforming the given node and all its descendants
 // using the given function.
-func Transform[T, U any](t *Node[T], f func(T) U) *Node[U] {
+func Transform[T, U any](t *Node[T], f func(Cursor[T]) U) *Node[U] {
 	return &Node[U]{
-		Value: f(t.Value),
+		Value: f(Cursor[T]{n: t}),
 		List:  TransformList(t.List, f),
 	}
 }
@@ -40,10 +40,26 @@ func (n *Node[T]) Walk(f func(T) error) error {
 // List is a collection of nodes.
 type List[T any] []*Node[T]
 
+// Cursor points to a node in the tree.
+// It provides read-only access to information about the node.
+type Cursor[T any] struct {
+	n *Node[T]
+}
+
+// Value returns the value held by the node.
+func (c *Cursor[T]) Value() T {
+	return c.n.Value
+}
+
+// ChildCount returns the number of direct children of the node.
+func (c *Cursor[T]) ChildCount() int {
+	return len(c.n.List)
+}
+
 // TransformList creates a new node list
 // by transforming the given node list and all its descendants
 // using the given function.
-func TransformList[T, U any](t List[T], f func(T) U) List[U] {
+func TransformList[T, U any](t List[T], f func(Cursor[T]) U) List[U] {
 	if t == nil {
 		// Match nilness of the input.
 		return nil

--- a/internal/tree/node_test.go
+++ b/internal/tree/node_test.go
@@ -28,7 +28,17 @@ func TestTransform(t *testing.T) {
 		},
 	}
 
-	assert.Equal(t, want, Transform(give, strconv.Itoa))
+	nodes := make(map[int]int) // value -> child count
+	assert.Equal(t, want, Transform(give, func(c Cursor[int]) string {
+		nodes[c.Value()] = c.ChildCount()
+		return strconv.Itoa(c.Value())
+	}))
+	assert.Equal(t, map[int]int{
+		1: 2,
+		2: 1,
+		3: 0,
+		4: 0,
+	}, nodes)
 }
 
 func TestWalk(t *testing.T) {

--- a/testdata/e2e/basic.yaml
+++ b/testdata/e2e/basic.yaml
@@ -46,3 +46,20 @@
     ## Foo
 
     ## Bar
+
+- name: external link
+  give: |
+    - [foo](foo.md)
+    - [bar](https://example.com)
+    - [baz](baz.md)
+  files:
+    foo.md: "# Hello"
+    baz.md: "# World"
+  want: |
+    - [foo](#hello)
+    - [bar](https://example.com)
+    - [baz](#world)
+
+    # Hello
+
+    # World

--- a/testdata/errors.yaml
+++ b/testdata/errors.yaml
@@ -1,0 +1,13 @@
+# For 'want', if an entry begins with '/',
+# it's treated as a regular expression.
+
+- name: external link no children
+  give: |
+    - [foo](foo.md)
+    - [bar](https://example.com)
+      - [baz](baz.md)
+  files:
+    foo.md: '# Foo'
+    baz.md: '# Baz'
+  want:
+    - "2:3:external link cannot have children"

--- a/transform.go
+++ b/transform.go
@@ -53,6 +53,8 @@ func (t *transformer) transformItem(item markdownItem) {
 		t.transformGroup(item)
 	case *markdownFileItem:
 		t.transformFile(item)
+	case *markdownExternalLinkItem:
+		// Nothing to do.
 	default:
 		panic(fmt.Sprintf("unknown item type: %T", item))
 	}


### PR DESCRIPTION
Adds support for external links in the TOC.
External links are reproduced verbatim in the output.

Resolves #2
