### PR TITLE
Degrade gracefully for headers > level 6

### DIFF
--- a/.changes/unreleased/Fixed-20230424-194932.yaml
+++ b/.changes/unreleased/Fixed-20230424-194932.yaml
@@ -1,0 +1,4 @@
+kind: Fixed
+body: For headers too deep to be represented in Markdown, render an anchor and bold
+  text.
+time: 2023-04-24T19:49:32.927734387-07:00

--- a/collect.go
+++ b/collect.go
@@ -220,7 +220,7 @@ func (c *collector) collectFileItem(item *stitch.LinkItem) (*markdownFileItem, e
 		// if any of them is a level 1 header.
 		if len(h1s) > 0 {
 			for _, h := range mf.Headings {
-				h.AST.Level++
+				h.Lvl++
 			}
 		}
 		mf.Headings = append([]*markdownHeading{mf.Title}, mf.Headings...)
@@ -233,6 +233,8 @@ func (c *collector) collectFileItem(item *stitch.LinkItem) (*markdownFileItem, e
 type markdownGroupItem struct {
 	Item    *stitch.TextItem
 	Heading *markdownHeading
+
+	src []byte
 }
 
 func (*markdownGroupItem) markdownItem() {}
@@ -248,13 +250,15 @@ func (c *collector) collectGroupItem(item *stitch.TextItem) *markdownGroupItem {
 		Heading: &markdownHeading{
 			AST: h,
 			ID:  id,
+			Lvl: h.Level,
 		},
 	}
 }
 
 type markdownHeading struct {
-	AST *ast.Heading
+	AST ast.Node
 	ID  string
+	Lvl int
 
 	// ID of the heading in the original file.
 	OldID string
@@ -268,9 +272,10 @@ func (c *collector) newHeading(f *goldast.File, fgen *header.IDGen, h *ast.Headi
 		AST:   h,
 		ID:    id,
 		OldID: oldID,
+		Lvl:   h.Level,
 	}
 }
 
 func (h *markdownHeading) Level() int {
-	return h.AST.Level
+	return h.Lvl
 }

--- a/generate.go
+++ b/generate.go
@@ -83,7 +83,7 @@ func (g *generator) renderItem(item markdownItem) error {
 
 func (g *generator) renderGroupItem(group *markdownGroupItem) error {
 	g.addHeadingSep()
-	if err := g.Renderer.Render(g.W, nil, group.Heading.AST); err != nil {
+	if err := g.Renderer.Render(g.W, group.src, group.Heading.AST); err != nil {
 		return err
 	}
 	io.WriteString(g.W, "\n")

--- a/testdata/e2e/header.yaml
+++ b/testdata/e2e/header.yaml
@@ -65,3 +65,68 @@
     ## Foo
 
     I collide with the other one.
+
+- name: header too high
+  give: |
+    - One
+      - Two
+        - Three
+          - Four
+            - Five
+              - [Six](six.md)
+                - Twelve
+                  - Thirteen
+                    - [Fourteen](fourteen.md)
+  files:
+    six.md: |
+      # Six
+
+      ## Seven
+
+      ### Eight
+
+      #### Nine
+
+      ##### Ten
+
+      ###### Eleven
+    fourteen.md: |
+      # Fourteen
+  want: |
+    - [One](#one)
+      - [Two](#two)
+        - [Three](#three)
+          - [Four](#four)
+            - [Five](#five)
+              - [Six](#six)
+                - [Twelve](#twelve)
+                  - [Thirteen](#thirteen)
+                    - [Fourteen](#fourteen)
+
+    # One
+
+    ## Two
+
+    ### Three
+
+    #### Four
+
+    ##### Five
+
+    ###### Six
+
+    <a id="seven"></a> **Seven**
+
+    <a id="eight"></a> **Eight**
+
+    <a id="nine"></a> **Nine**
+
+    <a id="ten"></a> **Ten**
+
+    <a id="eleven"></a> **Eleven**
+
+    <a id="twelve"></a> **Twelve**
+
+    <a id="thirteen"></a> **Thirteen**
+
+    <a id="fourteen"></a> **Fourteen**


### PR DESCRIPTION
Markdown can only render headers up to level 6.
With stitchmd, it's easy to accidentally write headers that are deeper.

This change renders headers deeper than level 6 in the form:

    <a id="foo"></a> **Foo**

This will keep links working even in deeply nested headings.

Resolves #8
