### PR TITLE
Add -unsafe flag to support ../ in summary

### DIFF
--- a/.changes/unreleased/Added-20231024-182442.yaml
+++ b/.changes/unreleased/Added-20231024-182442.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Add -unsafe flag to reference files outside the current directory.
+time: 2023-10-24T18:24:42.261277124-07:00

--- a/collect.go
+++ b/collect.go
@@ -160,6 +160,14 @@ func (*markdownFileItem) markdownItem() {}
 func (c *collector) collectFileItem(item *stitch.LinkItem) (*markdownFileItem, error) {
 	src, err := fs.ReadFile(c.FS, item.Target)
 	if err != nil {
+		// If the error is because the path name was not valid,
+		// it likely contains "." or ".." components,
+		// or has a "/" at the start or end of the path.
+		// Provide a hint to the user.
+		if errors.Is(err, fs.ErrInvalid) {
+			return nil, fmt.Errorf("invalid path name %q; did you mean to use -unsafe?", item.Target)
+		}
+
 		return nil, err
 	}
 

--- a/flags.go
+++ b/flags.go
@@ -24,6 +24,7 @@ type params struct {
 	Dir     string
 	Offset  int
 	NoTOC   bool
+	Unsafe  bool
 
 	Diff        bool
 	ColorOutput colorOutput
@@ -54,6 +55,7 @@ func (p *cliParser) newFlagSet() (*params, *flag.FlagSet) {
 	flag.Var(&opts.ColorOutput, "color", "")
 	flag.BoolVar(&opts.Diff, "d", false, "")
 	flag.BoolVar(&opts.Diff, "diff", false, "")
+	flag.BoolVar(&opts.Unsafe, "unsafe", false, "")
 
 	flag.BoolVar(&p.version, "version", false, "")
 	flag.BoolVar(&p.help, "help", false, "")

--- a/testdata/e2e/basic.yaml
+++ b/testdata/e2e/basic.yaml
@@ -63,3 +63,20 @@
     # Hello
 
     # World
+
+- name: unsafe
+  unsafe: true
+  give: |
+    - [A](a.md)
+    - [B](../b.md)
+  files:
+    foo/a.md: '# A'
+    b.md: '# B'
+  dir: foo
+  want: |
+    - [A](#a)
+    - [B](#b)
+
+    # A
+
+    # B

--- a/testdata/errors.yaml
+++ b/testdata/errors.yaml
@@ -11,3 +11,15 @@
     baz.md: '# Baz'
   want:
     - "2:3:external link cannot have children"
+
+- name: parent file not allowed
+  give: |
+    - [A](a.md)
+    - [B](../b.md)
+  files:
+    foo/a.md: '# A'
+    b.md: '# B'
+  dir: foo
+  want:
+    - invalid path name "../b.md"
+    - did you mean to use -unsafe

--- a/usage.txt
+++ b/usage.txt
@@ -24,6 +24,8 @@ OPTIONS
 	This is valid only if -o is also specified.
   -color [always|never|auto]
 	whether to use color in the command output. Defaults to 'auto'.
+  -unsafe
+	allow unsafe file references.
   -version
 	print version information.
   -h, -help


### PR DESCRIPTION
As a safety measure, we use os.DirFS to disallow referencing files
outside the current directory (or the `-C` directory).
Users can work around this by adding symlinks to the current directory.

This adds an `-unsafe` flag to drop this restriction,
and allow referencing files elsewhere in the file system.

As a small UX improvement, if we encounter these paths without the flag,
we'll let users know that the -unsafe flag exists.

Refs #111
