### PR TITLE
Support summary includes

### DIFF
--- a/.changes/unreleased/Added-20231106-213817.yaml
+++ b/.changes/unreleased/Added-20231106-213817.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Summary files now support including other summary files with the syntax `![Title](file.md)`.
+time: 2023-11-06T21:38:17.690154214-08:00

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@
 - [Usage](#usage)
   - [Options](#options)
   - [Syntax](#syntax)
+- [Advanced](#advanced)
   - [Page Titles](#page-titles)
+  - [Including summaries](#including-summary-files)
 - [License](#license)
 
 ## Introduction
@@ -713,6 +715,19 @@ to indicate a hierarchy.
   ```
     </details>
 
+- **Inclusions** of other summary files:
+  These are links in the form `![title](file.md)`.
+  The included file will be read as another summary file,
+  and its sections will nested under this heading.
+
+    <details>
+    <summary>Example</summary>
+
+  ```markdown
+  - ![FAQ](faq.md)
+  ```
+    </details>
+
 - **Plain text**:
   These will become standalone headers in the output.
   These **must** have a nested list.
@@ -821,6 +836,8 @@ for included documents: one plus the section level.
 
 </details>
 
+## Advanced
+
 ### Page Titles
 
 All pages included with stitchmd are assigned a title.
@@ -888,6 +905,96 @@ Welcome to Foo.
 ```
 
 </details>
+
+### Including summary files
+
+List items in the following form are requests to include another summary file:
+
+```markdown
+- ![title](file.md)
+```
+
+The list defined in the included summary file will be nested under this item.
+For example, given the following:
+
+```markdown
+<!-- use/summary.md -->
+
+- [Installation](install.md)
+- [Configuration](config.md)
+
+<!-- maintain/summary.md -->
+
+- [Dashboard](dashboard.md)
+- [Troubleshooting](troubleshooting.md)
+```
+
+A joint summary file could take the form:
+
+```markdown
+- ![Usage](use/summary.md)
+- ![Maintenance](maintain/summary.md)
+```
+
+<details>
+<summary>Output</summary>
+
+```markdown
+- [Usage](#usage)
+  - [Installation](#installation)
+  - [Configuration](#configuration)
+- [Maintenance](#maintenance)
+  - [Dashboard](#dashboard)
+  - [Troubleshooting](#troubleshooting)
+
+# Usage
+
+## Installation
+
+<!-- ... -->
+
+## Configuration
+
+<!-- ... -->
+
+# Maintenance
+
+## Dashboard
+
+<!-- ... -->
+
+## Troubleshooting
+
+<!-- ... -->
+```
+
+</details>
+
+Markdown files referenced in the included summary files
+are relative to the summary file.
+In the example above, the file tree would be:
+
+```
+.
+|- summary.md
+|- use
+|  |- summary.md
+|  |- install.md
+|  '- config.md
+'- maintain
+   |- summary.md
+   |- dashboard.md
+   '- troubleshooting.md
+```
+
+Limitations of included summary files:
+
+- It is an error to define more than one section
+  in an included summary file.
+- The section title's heading level does not affect
+  the level of items defined in that summary file.
+  The position of the included file in the parent file
+  determines levelling.
 
 ## License
 

--- a/collect.go
+++ b/collect.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"io/fs"
 	"net/url"
+	"path/filepath"
+	"strings"
 
 	"github.com/yuin/goldmark/ast"
 	"github.com/yuin/goldmark/parser"
@@ -21,6 +23,14 @@ type collector struct {
 	Parser parser.Parser // required
 	FS     fs.FS         // required
 
+	// Paths relative to root of fs.FS,
+	// representing the stack of summary file embeds.
+	// Used to detect cycles.
+	Stack []string
+
+	// Directory under FS to resolve relative paths from.
+	Dir string
+
 	idGen *header.IDGen
 	files map[string]*markdownFileItem
 }
@@ -35,7 +45,9 @@ type markdownCollection struct {
 
 func (c *collector) Collect(info goldast.Positioner, toc *stitch.Summary) (*markdownCollection, error) {
 	c.files = make(map[string]*markdownFileItem)
-	c.idGen = header.NewIDGen()
+	if c.idGen == nil {
+		c.idGen = header.NewIDGen()
+	}
 
 	errs := goldast.NewErrorList(info)
 	sections := make([]*markdownSection, len(toc.Sections))
@@ -82,6 +94,7 @@ func (c *collector) collectSection(errs *goldast.ErrorList, sec *stitch.Section)
 //   - markdownFileItem: an included Markdown file
 //   - markdownGroupItem: a title without any files, grouping other items
 //   - markdownExternalLinkItem: an external link
+//   - markdownEmbedItem: a request to embed another summary file
 type markdownItem interface {
 	markdownItem()
 }
@@ -91,6 +104,9 @@ func (c *collector) collectItem(cursor tree.Cursor[stitch.Item]) (markdownItem, 
 	switch item := item.(type) {
 	case *stitch.LinkItem:
 		return c.collectLinkItem(item, cursor)
+
+	case *stitch.EmbedItem:
+		return c.collectEmbedItem(item, cursor)
 
 	case *stitch.TextItem:
 		return c.collectGroupItem(item), nil
@@ -176,7 +192,8 @@ func (c *collector) collectFileItem(item *stitch.LinkItem) (*markdownFileItem, e
 		htmlBlocks []*ast.HTMLBlock
 	)
 	headingsByOldID := make(map[string]*markdownHeading)
-	err = goldast.Walk(f.AST, func(n ast.Node) error {
+	// Error ignored because walker doesn't return errors.
+	_ = goldast.Walk(f.AST, func(n ast.Node) error {
 		switch n := n.(type) {
 		case *ast.Link:
 			links = append(links, n)
@@ -196,9 +213,6 @@ func (c *collector) collectFileItem(item *stitch.LinkItem) (*markdownFileItem, e
 		}
 		return nil
 	})
-	if err != nil {
-		return nil, err
-	}
 
 	mf := &markdownFileItem{
 		Path:            item.Target,
@@ -270,6 +284,97 @@ func (c *collector) collectGroupItem(item *stitch.TextItem) *markdownGroupItem {
 	}
 }
 
+type markdownEmbedItem struct {
+	Item        *stitch.EmbedItem
+	Section     *markdownSection
+	FilesByPath map[string]*markdownFileItem
+	Heading     *markdownHeading
+	SummaryFile *goldast.File
+
+	src []byte
+}
+
+var _ markdownItem = (*markdownEmbedItem)(nil)
+
+func (c *collector) collectEmbedItem(item *stitch.EmbedItem, cursor tree.Cursor[stitch.Item]) (*markdownEmbedItem, error) {
+	if cursor.ChildCount() > 0 {
+		return nil, errors.New("embed cannot have children")
+	}
+
+	embedPath := filepath.Join(c.Dir, item.Target)
+	for _, p := range c.Stack {
+		if p == embedPath {
+			return nil, fmt.Errorf("embed cycle: %v", strings.Join(append(c.Stack, embedPath), " -> "))
+		}
+	}
+	summaryStack := append(c.Stack, embedPath)
+
+	src, err := c.readFile(item.Target)
+	if err != nil {
+		return nil, err
+	}
+
+	summaryFile := goldast.Parse(c.Parser, embedPath, src)
+	summary, err := stitch.ParseSummary(summaryFile)
+	if err != nil {
+		return nil, err
+	}
+
+	coll, err := (&collector{
+		Dir:    filepath.Join(c.Dir, filepath.Dir(item.Target)),
+		Parser: c.Parser,
+		FS:     c.FS,
+		idGen:  c.idGen,
+		Stack:  summaryStack,
+	}).Collect(summaryFile.Info, summary)
+	if err != nil {
+		return nil, err
+	}
+
+	switch len(coll.Sections) {
+	case 0:
+		// Unreachable: ParseSummary always returns at least one section.
+		return nil, errors.New("no sections found")
+	case 1:
+		// ok
+	default:
+		pos := summaryFile.Position(goldast.OffsetOf(coll.Sections[1].Title))
+		return nil, fmt.Errorf("%v:unexpected section; expected only one section", pos)
+	}
+
+	section := coll.Sections[0]
+	var heading *markdownHeading
+
+	if h := section.Title; h != nil {
+		heading = c.newHeading(summaryFile, c.idGen, h)
+		// Ignore the heading level in the summary file.
+		// It'll get whatever the depth of the embed is.
+		heading.Lvl = 0
+	} else {
+		// The included file does not have a title.
+		// Generate one from the TOC link.
+		h := ast.NewHeading(1) // will be transformed
+		h.AppendChild(h, ast.NewString([]byte(item.Text)))
+		h.SetBlankPreviousLines(true)
+		id, _ := c.idGen.GenerateID(item.Text)
+		heading = &markdownHeading{
+			AST: h,
+			ID:  id,
+			Lvl: h.Level,
+		}
+	}
+
+	return &markdownEmbedItem{
+		Item:        item,
+		Section:     section,
+		FilesByPath: coll.FilesByPath,
+		SummaryFile: summaryFile,
+		Heading:     heading,
+	}, nil
+}
+
+func (*markdownEmbedItem) markdownItem() {}
+
 type markdownHeading struct {
 	AST ast.Node
 	ID  string
@@ -297,7 +402,7 @@ func (h *markdownHeading) Level() int {
 
 // readFile reads a file from the underlying filesystem.
 func (c *collector) readFile(path string) ([]byte, error) {
-	src, err := fs.ReadFile(c.FS, path)
+	src, err := fs.ReadFile(c.FS, filepath.Join(c.Dir, path))
 	if err != nil {
 		// If the error is because the path name was not valid,
 		// it likely contains "." or ".." components,

--- a/design/4-summary-includes.adoc
+++ b/design/4-summary-includes.adoc
@@ -1,0 +1,109 @@
+= Distributed summary documents with Summary Includes
+2023-11-04
+:toc: preamble
+
+Abstract::
+  Proposes an extension to stitchmd's summary document format
+  to support including other partial summary documents.
+  This enables stitching together of the summary document
+  from fragments spread across files.
+Issue::
+  https://github.com/abhinav/stitchmd/issues/4[#4]
+
+== Background
+
+With stitchmd, the layout of the output is specified in a *summary file*.
+The summary file is a Markdown subset:
+it's valid Markdown, but very restricted about what's allowed.
+Individual documents are referenced in an itemized list in the summary file.
+
+Three kinds of items are supported in the list:
+
+File reference::
+  References a Markdown file that should be included in the output
+  at that position and nesting level.
+Group::
+  Header under which other items are grouped,
+  but does not represent another document.
+External link::
+  Link to an external resource.
+  These are produced verbatim in the output.
+
+.Kinds of items
+[,markdown,line-comment=#]
+----
+- [Introduction](intro.md) # <1>
+- Getting started # <2>
+  - [Installation](install.md)
+  - [Usage](usage.md)
+- [Community](https://example.com/discussions) # <3>
+----
+<1> File reference
+<2> Group
+<3> External link
+
+== Problem
+
+The summary file format is a central place for the output layout.
+This presents two obvious problems:
+
+* The summary file can grow large and ungainly
+  if you have lots of nested sections in different places.
+* If the same information has to be reproduced in different output documents,
+  the summary documents for both must duplicate those items
+  instead of being able to re-use the shared fragment.
+
+== Design
+
+As a solution, a new kind of summary list item will be added:
+*summary include*.
+A summary include is a request to load another summary file
+and nest its contents at the current position.
+
+=== Syntax
+
+The syntax for a summary include item will reuse the Markdown image syntax.
+
+[,markdown]
+----
+![title](file.md)
+----
+
+The image syntax includes a general suggestion of embedding something
+in the current document so it's a good fit for this purpose.
+
+=== Example
+
+With a summary document like the following:
+
+[,markdown]
+----
+- ![Using the web UI](web/SUMMARY.md)
+- ![Using the CLI](cli/SUMMARY.md)
+----
+
+stitchmd will load the referenced summaries
+and treat the result equivalent to the following:
+
+[,markdown,line-comment=#]
+----
+- Using the web UI # <1>
+  - [Create an account](web/register.md) <2>
+  - [Submit a request](web/submit.md)
+- Using the CLI
+  - [Authorize your terminal](cli/auth.md)
+  - [Submit a JSON request](cli/json.md)
+----
+<1> Included summaries are nested under a group named after the link title.
+<2> Links to files referenced inside included summaries
+    are adjusted to be relative to the parent summary file.
+
+== Future work
+
+In the future, we may allow:
+
+* Including another summary file without showing its items in the TOC.
+* Body in the summary file below the item list to be reproduced verbatim.
+
+The two pieces combined would fully address the scenario
+originally imagined in https://github.com/abhinav/stitchmd/issues/4[#4].

--- a/doc/README.md
+++ b/doc/README.md
@@ -7,5 +7,7 @@
 - [Usage](usage.md)
   - [Options](options.md)
   - [Syntax](syntax.md)
+- Advanced
   - [Page Titles](titles.md)
+  - [Including summaries](include.md)
 - [License](license.md)

--- a/doc/include.md
+++ b/doc/include.md
@@ -1,0 +1,89 @@
+# Including summary files
+
+List items in the following form are requests to include another summary file:
+
+```markdown
+- ![title](file.md)
+```
+
+The list defined in the included summary file will be nested under this item.
+For example, given the following:
+
+```markdown
+<!-- use/summary.md -->
+
+- [Installation](install.md)
+- [Configuration](config.md)
+
+<!-- maintain/summary.md -->
+
+- [Dashboard](dashboard.md)
+- [Troubleshooting](troubleshooting.md)
+```
+
+A joint summary file could take the form:
+
+```markdown
+- ![Usage](use/summary.md)
+- ![Maintenance](maintain/summary.md)
+```
+
+<details>
+<summary>Output</summary>
+
+```markdown
+- [Usage](#usage)
+  - [Installation](#installation)
+  - [Configuration](#configuration)
+- [Maintenance](#maintenance)
+  - [Dashboard](#dashboard)
+  - [Troubleshooting](#troubleshooting)
+
+# Usage
+
+## Installation
+
+<!-- ... -->
+
+## Configuration
+
+<!-- ... -->
+
+# Maintenance
+
+## Dashboard
+
+<!-- ... -->
+
+## Troubleshooting
+
+<!-- ... -->
+```
+
+</details>
+
+Markdown files referenced in the included summary files
+are relative to the summary file.
+In the example above, the file tree would be:
+
+```
+.
+|- summary.md
+|- use
+|  |- summary.md
+|  |- install.md
+|  '- config.md
+'- maintain
+   |- summary.md
+   |- dashboard.md
+   '- troubleshooting.md
+```
+
+Limitations of included summary files:
+
+- It is an error to define more than one section
+  in an included summary file.
+- The section title's heading level does not affect
+  the level of items defined in that summary file.
+  The position of the included file in the parent file
+  determines levelling.

--- a/doc/syntax.md
+++ b/doc/syntax.md
@@ -45,6 +45,19 @@ to indicate a hierarchy.
     ```
     </details>
 
+- **Inclusions** of other summary files:
+  These are links in the form `![title](file.md)`.
+  The included file will be read as another summary file,
+  and its sections will nested under this heading.
+
+    <details>
+    <summary>Example</summary>
+
+    ```markdown
+    - ![FAQ](faq.md)
+    ```
+    </details>
+
 - **Plain text**:
   These will become standalone headers in the output.
   These **must** have a nested list.

--- a/integration_test.go
+++ b/integration_test.go
@@ -220,7 +220,7 @@ func TestIntegration_errors(t *testing.T) {
 		Want []string `yaml:"want"`
 	}
 
-	groups := decodeTestGroups[testCase](t, "testdata/errors.yaml")
+	groups := decodeTestGroups[testCase](t, "testdata/errors/*.yaml")
 	var tests []testCase
 	for _, group := range groups {
 		for _, tt := range group.Tests {

--- a/internal/stitch/summary_test.go
+++ b/internal/stitch/summary_test.go
@@ -36,6 +36,17 @@ func TestParseSummary(t *testing.T) {
 		}
 	}
 
+	embedItem := func(depth int, text, dest string, children ...*tree.Node[Item]) *tree.Node[Item] {
+		return &tree.Node[Item]{
+			Value: &EmbedItem{
+				Text:   text,
+				Target: dest,
+				Depth:  depth,
+			},
+			List: tree.List[Item](children),
+		}
+	}
+
 	section := func(lvl int, title string, items ...*tree.Node[Item]) *Section {
 		var stitle *SectionTitle
 		if len(title) > 0 {
@@ -152,6 +163,13 @@ func TestParseSummary(t *testing.T) {
 				section(0, "", linkItem(0, "foo", "https://example.com")),
 			),
 		},
+		{
+			desc: "embed link",
+			give: "- ![foo](foo.md)",
+			want: toc(
+				section(0, "", embedItem(0, "foo", "foo.md")),
+			),
+		},
 	}
 
 	for _, tt := range tests {
@@ -176,6 +194,8 @@ func TestParseSummary(t *testing.T) {
 					case *LinkItem:
 						i.AST = nil
 					case *TextItem:
+						i.AST = nil
+					case *EmbedItem:
 						i.AST = nil
 					default:
 						t.Fatalf("unexpected item type %T", i)

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 	"io/fs"
 	"log"
 	"os"
+	"path"
 	"path/filepath"
 
 	mdfmt "github.com/Kunde21/markdownfmt/v3/markdown"
@@ -141,6 +142,17 @@ func (cmd *mainCmd) run(opts *params) (err error) {
 	inputDir := determineDir(opts.Input)
 	outputDir := determineDir(opts.Output)
 
+	// /-separated relative path to the input file from the input directory.
+	// Empty if the input file is stdin.
+	var filenameRel string
+	if len(opts.Input) > 0 {
+		filenameRel, err = filepath.Rel(inputDir, filename)
+		if err != nil {
+			return err
+		}
+		filenameRel = filepath.ToSlash(filenameRel)
+	}
+
 	output := cmd.Stdout
 	if len(opts.Output) > 0 {
 		if opts.Diff {
@@ -201,7 +213,7 @@ func (cmd *mainCmd) run(opts *params) (err error) {
 		),
 	)
 
-	f := goldast.Parse(mdParser, filename, src)
+	f := goldast.Parse(mdParser, filenameRel, src)
 	summary, err := stitch.ParseSummary(f)
 	if err != nil {
 		log.Println(err)
@@ -213,10 +225,15 @@ func (cmd *mainCmd) run(opts *params) (err error) {
 		collectFS = unsafeDirFS(inputDir)
 	}
 
+	var collectorStack []string
+	if len(filenameRel) > 0 {
+		collectorStack = append(collectorStack, filenameRel)
+	}
+
 	coll, err := (&collector{
 		FS:     collectFS,
 		Parser: mdParser,
-		Stack:  []string{filename},
+		Stack:  collectorStack,
 	}).Collect(f.Info, summary)
 	if err != nil {
 		log.Println(err)
@@ -252,6 +269,7 @@ type unsafeDirFS string
 var _ fs.FS = unsafeDirFS("")
 
 func (dir unsafeDirFS) Open(name string) (fs.File, error) {
+	name = filepath.FromSlash(name)
 	return os.Open(filepath.Join(string(dir), name))
 }
 
@@ -297,8 +315,8 @@ func (dw *diffWriter) Diff(w io.Writer) error {
 	}
 
 	return diff.Text(
-		filepath.Join("a", dw.fname),
-		filepath.Join("b", dw.fname),
+		path.Join("a", dw.fname),
+		path.Join("b", dw.fname),
 		dw.old,
 		dw.new.Bytes(),
 		w,

--- a/main.go
+++ b/main.go
@@ -216,6 +216,7 @@ func (cmd *mainCmd) run(opts *params) (err error) {
 	coll, err := (&collector{
 		FS:     collectFS,
 		Parser: mdParser,
+		Stack:  []string{filename},
 	}).Collect(f.Info, summary)
 	if err != nil {
 		log.Println(err)
@@ -226,6 +227,7 @@ func (cmd *mainCmd) run(opts *params) (err error) {
 		Log:          log,
 		Offset:       opts.Offset,
 		InputRelPath: filepath.ToSlash(inputRel),
+		SummaryFile:  f,
 	}).Transform(coll)
 
 	render := mdfmt.NewRenderer()

--- a/testdata/e2e/embed.yaml
+++ b/testdata/e2e/embed.yaml
@@ -1,0 +1,235 @@
+- name: simple
+  give: |
+    - [Foo](foo.md)
+    - ![Bar](bar.md)
+    - [Quux](quux.md)
+  files:
+    foo.md: "# Foo"
+    bar.md: |
+      - [Baz](baz.md)
+      - [Qux](qux.md)
+    baz.md: |
+      # Baz
+
+      Hello
+    qux.md: |
+      # Qux
+
+      World
+    quux.md: |
+      Stuff
+  want: |
+    - [Foo](#foo)
+    - [Bar](#bar)
+      - [Baz](#baz)
+      - [Qux](#qux)
+    - [Quux](#quux)
+
+    # Foo
+
+    # Bar
+
+    ## Baz
+
+    Hello
+
+    ## Qux
+
+    World
+
+    # Quux
+
+    Stuff
+
+- name: nested
+  give: |
+    - ![Foo](foo.md)
+  files:
+    foo.md: |
+      - ![Bar](bar.md)
+    bar.md: |
+      - ![Baz](baz.md)
+    baz.md: |
+      - [Qux](qux.md)
+    qux.md: |
+      Hello world
+  want: |
+    - [Foo](#foo)
+      - [Bar](#bar)
+        - [Baz](#baz)
+          - [Qux](#qux)
+
+    # Foo
+
+    ## Bar
+
+    ### Baz
+
+    #### Qux
+
+    Hello world
+
+- name: heading repeats
+  give: |
+    - ![Foo](foo.md)
+    - ![Foo](foo.md)
+    - ![Foo](foo.md)
+  files:
+    foo.md: |
+      - Bar
+        - [Baz](baz.md)
+    baz.md: |
+      # Baz
+  want: |
+    - [Foo](#foo)
+      - [Bar](#bar)
+        - [Baz](#baz)
+    - [Foo](#foo-1)
+      - [Bar](#bar-1)
+        - [Baz](#baz-1)
+    - [Foo](#foo-2)
+      - [Bar](#bar-2)
+        - [Baz](#baz-2)
+
+    # Foo
+
+    ## Bar
+
+    ### Baz
+
+    # Foo
+
+    ## Bar
+
+    ### Baz
+
+    # Foo
+
+    ## Bar
+
+    ### Baz
+
+- name: subdir paths
+  # Paths for the included summary
+  # are relative to that directory.
+  give: |
+    - ![CLI](cli/summary.md)
+  files:
+    cli/summary.md: |
+      - [Installation](install.md)
+      - [Usage](usage.md)
+    cli/install.md: |
+      How to install the CLI.
+    cli/usage.md: |
+      How to use the CLI.
+  want: |
+    - [CLI](#cli)
+      - [Installation](#installation)
+      - [Usage](#usage)
+
+    # CLI
+
+    ## Installation
+
+    How to install the CLI.
+
+    ## Usage
+
+    How to use the CLI.
+
+- name: subdir import parent
+  # An included summary in a subdirectory
+  # should be able to import a document in the parent.
+  give: |
+    - ![CLI](cli/summary.md)
+  files:
+    cli/summary.md: |
+      - [Installation](../install.md)
+      - [Usage](usage.md)
+    install.md: |
+      How to install the application.
+    cli/usage.md: |
+      How to use the CLI.
+  want: |
+    - [CLI](#cli)
+      - [Installation](#installation)
+      - [Usage](#usage)
+
+    # CLI
+
+    ## Installation
+
+    How to install the application.
+
+    ## Usage
+
+    How to use the CLI.
+
+- name: duplicate embeds
+  # Should be able to include the same summary multiple times.
+  give: |
+    - ![Left](left.md)
+    - ![Right](right.md)
+  files:
+    left.md: |
+      - ![Foo](foo.md)
+    right.md: |
+      - ![Foo](foo.md)
+    foo.md: |
+      - [Bar](bar.md)
+    bar.md: |
+      # Bar
+
+      Hello
+  want: |
+    - [Left](#left)
+      - [Foo](#foo)
+        - [Bar](#bar)
+    - [Right](#right)
+      - [Foo](#foo-1)
+        - [Bar](#bar-1)
+
+    # Left
+
+    ## Foo
+
+    ### Bar
+
+    Hello
+
+    # Right
+
+    ## Foo
+
+    ### Bar
+
+    Hello
+
+- name: embed heading
+  # Embeds section titles are used.
+  give: |
+    - ![Using the UI](ui/summary.md)
+  files:
+    ui/summary.md: |
+      # How to use the UI
+
+      - [Installation](install.md)
+      - [Usage](usage.md)
+    ui/install.md: |
+      Install the program.
+    ui/usage.md: |
+      Start the program.
+  want: |
+    - [Using the UI](#how-to-use-the-ui)
+      - [Installation](#installation)
+      - [Usage](#usage)
+
+    # How to use the UI
+
+    ## Installation
+
+    Install the program.
+
+    ## Usage
+
+    Start the program.

--- a/testdata/errors/basic.yaml
+++ b/testdata/errors/basic.yaml
@@ -21,5 +21,5 @@
     b.md: '# B'
   dir: foo
   want:
-    - invalid path name "../b.md"
+    - invalid path "../b.md"
     - did you mean to use -unsafe

--- a/testdata/errors/embed.yaml
+++ b/testdata/errors/embed.yaml
@@ -1,0 +1,86 @@
+- name: does not exist
+  give: |
+    - ![Bar](foo/bar.md)
+  want:
+    - "1:3:open"
+    - "no such file or directory"
+
+- name: external link no children
+  give: |
+    - ![Bar](foo/bar.md)
+  files:
+    foo/bar.md: |
+      - hi
+        - [bar](https://example.com)
+          - [baz](baz.md)
+    foo/baz.md: '# Baz'
+  want:
+    - "1:3:foo/bar.md:2:5:external link"
+
+- name: empty embed
+  give: |
+    - Foo
+      - ![Bar](bar.md)
+  files:
+    bar.md: |
+  want:
+    - "2:5:bar.md:1:1:no sections found"
+
+- name: children
+  give: |
+    - ![Foo](foo.md)
+      - [Bar](bar.md)
+  files:
+    foo.md: |
+      - [Bar](bar.md)
+    bar.md: |
+      # Bar
+  want:
+    - summary.md:1:3:embed cannot have children
+
+- name: too many sections
+  give: |
+    - ![Foo](foo.md)
+  files:
+    foo.md: |
+      # A
+
+      - [Bar](bar.md)
+      - [Baz](baz.md)
+
+      # B
+
+      - [Bar](bar.md)
+      - [Baz](baz.md)
+    bar.md: ""
+    baz.md: ""
+  want:
+    - "1:3:foo.md:6:3:unexpected section; expected only one section"
+
+- name: cycle
+  give: |
+    - ![Foo](foo.md)
+  files:
+    foo.md: |
+      - ![Bar](bar.md)
+    bar.md: |
+      - ![Baz](baz.md)
+    baz.md: |
+      - ![Foo](foo.md)
+  want:
+    - "embed cycle:"
+    - "foo.md -> bar.md -> baz.md -> foo.md"
+
+- name: cycle parent path
+  give: |
+    - ![Foo](a/foo.md)
+  files:
+    a/foo.md: |
+      - ![Bar](b/bar.md)
+    a/b/bar.md: |
+      - ![Baz](c/baz.md)
+    a/b/c/baz.md: |
+      - ![Foo](../../foo.md)
+  want:
+    - "embed cycle:"
+    - "a/foo.md -> a/b/bar.md -> a/b/c/baz.md -> a/foo.md"

--- a/testdata/errors/embed.yaml
+++ b/testdata/errors/embed.yaml
@@ -3,7 +3,7 @@
     - ![Bar](foo/bar.md)
   want:
     - "1:3:open"
-    - "no such file or directory"
+    - /no such file or directory|cannot find the path
 
 - name: external link no children
   give: |


### PR DESCRIPTION
Adds support for including summary files from other summary files.
The contents of the included file will be nested under the heading.
The syntax for this borrows from Markdown images:

```
- ![Nested](other/sumamry.md)
```

This will load the specified summary file
and nest its items under the given heading;
equivalent to the following.

```
- Nested
  - [Foo](foo.md)
  - [Bar](bar.md)
```

There are restrictions on the included summary file:

- It can have only one section.
- Its section title's level will be ignored.
  The item depth will inform the heading level.

Refs #113
Resolves #4
