### PR TITLE
make: Don't run tests with -v

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
     - name: Test
       run: make cover
       env:
-        TEST_FLAGS: '-v -race'
+        TEST_FLAGS: '-race'
       shell: bash
 
     - name: Upload coverage

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ export PATH := $(GOBIN):$(PATH)
 
 STITCHMD = bin/stitchmd
 STITCHMD_ARGS = -o README.md -preface doc/preface.txt doc/README.md
-TEST_FLAGS ?= -v -race
+TEST_FLAGS ?= -race
 
 # Non-test Go files.
 GO_SRC_FILES = $(shell find . \


### PR DESCRIPTION
Makes it harder to track down failures.
