### PR TITLE
Support absorbing TOC items

### DIFF
--- a/.changes/unreleased/Added-20240616-152529.yaml
+++ b/.changes/unreleased/Added-20240616-152529.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: 'Included files can add `absorb: true` to their YAML front matter to include their headings in the summary TOC automatically.'
+time: 2024-06-16T15:25:29.537315-07:00

--- a/README.md
+++ b/README.md
@@ -11,9 +11,17 @@
   - [GitHub Action](#github-action)
 - [Usage](#usage)
   - [Options](#options)
+    - [Read from stdin](#read-from-stdin)
+    - [Add a preface](#add-a-preface)
+    - [Offset heading levels](#offset-heading-levels)
+    - [Disable the TOC](#disable-the-toc)
+    - [Write to file](#write-to-file)
+    - [Change the directory](#change-the-directory)
+    - [Report a diff](#report-a-diff)
   - [Syntax](#syntax)
 - [Advanced](#advanced)
   - [Page Titles](#page-titles)
+  - [Absorbing headings](#absorbing-headings)
   - [Including summaries](#including-summary-files)
 - [License](#license)
 
@@ -902,6 +910,68 @@ The title for `intro.md` will be `"Introduction to Foo"`.
 # Introduction to Foo
 
 Welcome to Foo.
+```
+
+</details>
+
+### Absorbing headings
+
+When adding another Markdown file to your summary,
+you can pull the headings of the included file in the final output
+by adding a YAML front matter block to the top of the file.
+
+```yaml
+---
+absorb: true
+---
+```
+
+For example, given the following:
+
+```markdown
+<!-- summary.md -->
+
+- [Installation](install.md)
+- [Configuration](config.md)
+
+<!-- config.md -->
+---
+absorb: true
+---
+
+# Configuration
+
+## Adding a new user
+
+To add a new user, ...
+
+## Removing a user
+
+To remove a user, ...
+```
+
+<details>
+<summary>Output</summary>
+
+```markdown
+- [Installation](#install)
+- [Configuration](#configuration)
+  - [Adding a new user](#adding-a-new-user)
+  - [Removing a user](#removing-a-user)
+
+# Installation
+
+<!-- ... -->
+
+# Configuration
+
+## Adding a new user
+
+To add a new user, ...
+
+## Removing a user
+
+To remove a user, ...
 ```
 
 </details>

--- a/doc/README.md
+++ b/doc/README.md
@@ -9,5 +9,6 @@
   - [Syntax](syntax.md)
 - Advanced
   - [Page Titles](titles.md)
+  - [Absorbing headings](absorb.md)
   - [Including summaries](include.md)
 - [License](license.md)

--- a/doc/absorb.md
+++ b/doc/absorb.md
@@ -1,0 +1,61 @@
+# Absorbing headings
+
+When adding another Markdown file to your summary,
+you can pull the headings of the included file in the final output
+by adding a YAML front matter block to the top of the file.
+
+```yaml
+---
+absorb: true
+---
+```
+
+For example, given the following:
+
+```markdown
+<!-- summary.md -->
+
+- [Installation](install.md)
+- [Configuration](config.md)
+
+<!-- config.md -->
+---
+absorb: true
+---
+
+# Configuration
+
+## Adding a new user
+
+To add a new user, ...
+
+## Removing a user
+
+To remove a user, ...
+```
+
+<details>
+<summary>Output</summary>
+
+```markdown
+- [Installation](#install)
+- [Configuration](#configuration)
+  - [Adding a new user](#adding-a-new-user)
+  - [Removing a user](#removing-a-user)
+
+# Installation
+
+<!-- ... -->
+
+# Configuration
+
+## Adding a new user
+
+To add a new user, ...
+
+## Removing a user
+
+To remove a user, ...
+```
+
+</details>

--- a/doc/options.md
+++ b/doc/options.md
@@ -1,3 +1,7 @@
+---
+absorb: true
+---
+
 # Options
 
 stitchmd supports the following options:

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/yuin/goldmark v1.7.1
 	go.abhg.dev/container/ring v0.3.0
 	go.abhg.dev/goldmark/frontmatter v0.2.0
+	go.abhg.dev/goldmark/toc v0.10.0
 	golang.org/x/net v0.26.0
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,8 @@ go.abhg.dev/container/ring v0.3.0 h1:sEYgxqyAsT2X1NkUEPQecR4WY7cZCbKZSGUsERhHyDI
 go.abhg.dev/container/ring v0.3.0/go.mod h1:GoB+vof3ofHqP2h2S97aJkmrMLK/Dyn7UEupDTgfWV8=
 go.abhg.dev/goldmark/frontmatter v0.2.0 h1:P8kPG0YkL12+aYk2yU3xHv4tcXzeVnN+gU0tJ5JnxRw=
 go.abhg.dev/goldmark/frontmatter v0.2.0/go.mod h1:XqrEkZuM57djk7zrlRUB02x8I5J0px76YjkOzhB4YlU=
+go.abhg.dev/goldmark/toc v0.10.0 h1:de3LrIimwtGhBMKh7aEl1c6n4XWwOdukIO5wOAMYZzg=
+go.abhg.dev/goldmark/toc v0.10.0/go.mod h1:OpH0qqRP9v/eosCV28ZeqGI78jZ8rri3C7Jh8fzEo2M=
 golang.org/x/net v0.26.0 h1:soB7SVo0PWrY4vPW/+ay0jKDNScG2X9wFeYlXIvJsOQ=
 golang.org/x/net v0.26.0/go.mod h1:5YKkiSynbBIh3p6iOc/vibscux0x38BZDkn8sCUPxHE=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -38,5 +40,5 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-pgregory.net/rapid v0.5.5 h1:jkgx1TjbQPD/feRoK+S/mXw9e1uj6WilpHrXJowi6oA=
-pgregory.net/rapid v0.5.5/go.mod h1:PY5XlDGj0+V1FCq0o192FdRhpKHGTRIWBgqjDBTrq04=
+pgregory.net/rapid v1.1.0 h1:CMa0sjHSru3puNx+J0MIAuiiEV4N0qj8/cMWGBBCsjw=
+pgregory.net/rapid v1.1.0/go.mod h1:PY5XlDGj0+V1FCq0o192FdRhpKHGTRIWBgqjDBTrq04=

--- a/testdata/e2e/absorb.yaml
+++ b/testdata/e2e/absorb.yaml
@@ -1,0 +1,92 @@
+- name: simple
+  give: |
+    - [Foo](foo.md)
+    - [Bar](bar.md)
+  files:
+    foo.md: |
+      ---
+      absorb: true
+      ---
+
+      # Foo
+
+      ## Introduction
+
+      ## How to foo
+
+    bar.md: |
+      ---
+      absorb: true
+      ---
+
+      # Introduction
+
+      # Details about bar
+  want: |
+    - [Foo](#foo)
+      - [Introduction](#introduction)
+      - [How to foo](#how-to-foo)
+    - [Bar](#bar)
+      - [Introduction](#introduction-1)
+      - [Details about bar](#details-about-bar)
+
+    # Foo
+
+    ## Introduction
+
+    ## How to foo
+
+    # Bar
+
+    ## Introduction
+
+    ## Details about bar
+
+- name: many levels
+  give: |
+    - Parent
+      - Child
+        - [Foo](foo.md)
+  files:
+    foo.md: |
+      ---
+      absorb: true
+      ---
+
+      # Foo
+
+      ## Level 2
+
+      ### Level 3
+
+      #### Level 4
+
+      ##### Level 5
+
+      ###### Level 6
+
+  want: |
+    - [Parent](#parent)
+      - [Child](#child)
+        - [Foo](#foo)
+          - [Level 2](#level-2)
+            - [Level 3](#level-3)
+              - [Level 4](#level-4)
+                - [Level 5](#level-5)
+                  - [Level 6](#level-6)
+
+    # Parent
+
+    ## Child
+
+    ### Foo
+
+    #### Level 2
+
+    ##### Level 3
+
+    ###### Level 4
+
+    <a id="level-5"></a> **Level 5**
+
+    <a id="level-6"></a> **Level 6**

--- a/testdata/e2e/header.yaml
+++ b/testdata/e2e/header.yaml
@@ -75,7 +75,7 @@
             - Five
               - [Six](six.md)
                 - Twelve
-                  - Thirteen
+                  - Thirteen levels
                     - [Fourteen](fourteen.md)
   files:
     six.md: |
@@ -100,7 +100,7 @@
             - [Five](#five)
               - [Six](#six)
                 - [Twelve](#twelve)
-                  - [Thirteen](#thirteen)
+                  - [Thirteen levels](#thirteen-levels)
                     - [Fourteen](#fourteen)
 
     # One
@@ -127,6 +127,6 @@
 
     <a id="twelve"></a> **Twelve**
 
-    <a id="thirteen"></a> **Thirteen**
+    <a id="thirteen-levels"></a> **Thirteen levels**
 
     <a id="fourteen"></a> **Fourteen**


### PR DESCRIPTION
Adds support for declaring that the headings of a file
should be absorbed into the TOC in the final document
by adding an 'absorb' front matter.

For example,

    ---
    absorb: true
    ---

    # Foo

    ## Bar

    ## Baz

When included with a `- [Foo](foo.md)` link, the final result
will include:

    - [Foo](#foo)
      - [Bar](#bar)
      - [Baz](#baz)

Resolves #134